### PR TITLE
Fix no-auth config for mongodb if/else statement

### DIFF
--- a/app.js
+++ b/app.js
@@ -93,8 +93,8 @@ var ObjectId = mongoose.SchemaTypes.ObjectId;
 require('mongoose-cache').install(mongoose, cacheOpts);
 
 var mongoUri = 'mongodb://' +
-(config.mongodb.user && config.mongodb.user.length > 0 ?
-  ( config.mongodb.user + ':' + config.mongodb.password + '@') : + "");
+((config.mongodb.user && config.mongodb.user.length > 0) ?
+  config.mongodb.user + ':' + config.mongodb.password + '@' : "");
   
 for (host in config.mongodb.hosts) {
     mongoUri += config.mongodb.hosts[host];


### PR DESCRIPTION
While:

var mongoUri = 'mongodb://' +
((config.mongodb.user && config.mongodb.user.length > 0) ?
  config.mongodb.user + ':' + config.mongodb.password + '@' : "");

returns:
"mongodb://test:test@"

if the username and password is set, it will return the following false value, if no username is set:
"mongodb://0"

This commit fixes the shorthand if/else statement so that no username correctly returns:
"mongodb://"

Follow up: 7fb2ccd77d4e8365b73b37609865d434936a34dd