### PR TITLE
Use relative URL instead of https://home.myopenhab.org/start/index

### DIFF
--- a/views/index.ejs
+++ b/views/index.ejs
@@ -102,7 +102,7 @@
                         case 'online':
                             if (openhabMajorVersion == '2') {
                 %>
-                                You are using openHAB 2.x. <a href="https://home.myopenhab.org/start/index">Click here to access your openHAB's dashboard</a>
+                                You are using openHAB 2.x. <a href="/start/index">Click here to access your openHAB's dashboard</a>
                 <%
                             } else {
                 %>


### PR DESCRIPTION
When one is running his own instance of OpenHab Cloud, he probably doesn't want
to access the public cloud on home.myopenhab.org