### PR TITLE
Add a new system module which holds system configuration

### DIFF
--- a/config-development.json
+++ b/config-development.json
@@ -1,6 +1,8 @@
 {
     "system": {
-    	"baseurl": "<your-openhab-cloud-host>:443",
+        "host": "<your-openhab-cloud-host>",
+        "port": "443",
+        "protocol": "https",
         "logging": "debug"
     },
     "express":{

--- a/config-production.json
+++ b/config-production.json
@@ -1,6 +1,8 @@
 {
     "system": {
-      "baseurl": "<your-openhab-cloud-host>:443",
+      "host": "<your-openhab-cloud-host>",
+      "port": "443",
+      "protocol": "https",
       "logging": "info",
       "subDomainCookies": false
     },

--- a/routes/account.js
+++ b/routes/account.js
@@ -24,6 +24,7 @@ var uuid = require('uuid');
 var mailer = require('../mailer');
 var logger = require('../logger');
 var app = require('../app');
+var system = require('../system');
 
 exports.lostpasswordget = function(req, res) {
     res.render('lostpassword', {title: "Lost my password", user: req.user,
@@ -48,7 +49,7 @@ exports.lostpasswordpost = function(req, res) {
                     if (!error) {
                         var locals = {
                             email: lostUser.username,
-                            resetUrl: "https://" + app.config.system.baseurl + "/lostpasswordreset?resetCode=" + recoveryCode
+                            resetUrl: system.getBaseURL() + "/lostpasswordreset?resetCode=" + recoveryCode
                         };
                         mailer.sendEmail(lostUser.username, "Password recovery", 'lostpassword-email', locals, function(error) {
                             if (!error) {

--- a/routes/ifttt.js
+++ b/routes/ifttt.js
@@ -7,6 +7,7 @@ var Openhab = require('../models/openhab');
 var Item = require('../models/item');
 var Event = require('../models/event');
 var app = require('../app');
+var system = require('../system');
 
 // IFTTT openHAB channel key
 var iftttChannelKey = app.config.ifttt.iftttChannelKey
@@ -53,7 +54,7 @@ function iftttAuthenticate (req, res, next) {
 exports.userinfo = [
     iftttAuthenticate,
     function(req, res){
-        res.json({data: {name: req.user.username, id: req.user._id, url: "https://" + app.config.system.baseurl + "/account"}});
+        res.json({data: {name: req.user.username, id: req.user._id, url: system.getBaseURL() + "/account"}});
     }
 ]
 

--- a/system/index.js
+++ b/system/index.js
@@ -1,0 +1,98 @@
+var url = require('url');
+var System = function() {};
+
+/**
+ * Sets the configuration object for this System object which should holf the configuration options for this instance
+ * of the app.
+ * @param {Object} config
+ */
+System.prototype.setConfiguration = function(config) {
+    if (typeof config != 'object')
+        throw new Error('config needs to be an object of configuration options, ' + typeof config + ' given.');
+
+    this.config = config;
+
+    // backward-compatibility to the baseurl property
+    if (this.config && this.config.system && this.config.system.hasOwnProperty('baseurl')) {
+        var parsedUrl, baseurl = this.config.system.baseurl;
+
+        // anything will match, except URLs without protocol, like:
+        // localhost:3000
+        // localhost/openhab
+        // and so on. For these baseurl, for backward-compatibility, the protocol http: is prepended
+        if (!baseurl.match(/^.*:?\/\/.*:[0-9]{1,5}/g)) {
+            baseurl = 'http:' + baseurl;
+        }
+        parsedUrl = url.parse(baseurl, false, true);
+        this.config.system.host = parsedUrl.hostname;
+        this.config.system.port = parsedUrl.port;
+        this.config.system.protocol = (parsedUrl.protocol || 'http:').replace(':', '');
+    }
+};
+
+/**
+ * Returns the value of the given configuration or configuration path, if the configuration exists.
+ *
+ * @param {String|Array} config The configuration name as a string, if it is at the top level of the config
+ *  object or as an array of strings, which represents the path to the requested config.
+ * @returns {*} The value of the configuration, which can be a string, boolean, object, array or any other supported
+ *  data type.
+ * @throws Error Throws an error, if the configuration was not set (using #setConfiguration) so far, or the
+ *  requested configuration does not exist or couldn't be found at the provided path.
+ * @private
+ */
+System.prototype.getConfig = function(config) {
+    var localConfig = this.config;
+
+    if (!this.config)
+        throw new Error('No configuration object set so far.');
+
+    if (Array.isArray(config)) {
+        config.forEach(function(element) {
+            if (localConfig.hasOwnProperty(element))
+                localConfig = localConfig[element];
+            else
+                throw new Error('Could not find configuration path: ' + config + '. Stopped at: ' + element);
+        });
+        return localConfig;
+    }
+
+    if (this.config.hasOwnProperty(config))
+        return this.config[config];
+
+    throw new Error('The configuration ' + config +  ' could not be found.');
+};
+
+/**
+ * Returns the configured host of the system. This can be different from the host where this app is running.
+ * @returns {String}
+ */
+System.prototype.getHost = function() {
+    return this.getConfig(['system', 'host']);
+};
+
+/**
+ * Returns the port configured for this system.
+ * @returns {int}
+ */
+System.prototype.getPort = function() {
+    return this.getConfig(['system', 'port']);
+};
+
+/**
+ * Returns the configured protocol to use for this app instance.
+ * @returns {String}
+ */
+System.prototype.getProtocol = function() {
+    return this.getConfig(['system', 'protocol']);
+};
+
+/**
+ * Returns the full base URL of this app, which consists of a protocol, the host and port without a trailing slash.
+ * @return {String}
+ */
+System.prototype.getBaseURL = function() {
+    return this.getProtocol() + '://' + this.getHost() + ':' + this.getPort();
+};
+
+module.exports = new System();

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -105,11 +105,11 @@
                         case 'online':
                             if (openhabMajorVersion == '2') {
                 %>
-                                You are using openHAB 2.x. <a href="https://home.myopenhab.org/start/index">Click here to access your openHAB's dashboard</a>
+                                You are using openHAB 2.x. <a href="<%=baseurl%>/start/index">Click here to access your openHAB's dashboard</a>
                 <%
                             } else {
                 %>
-                                You are using openHAB 1.x. To remotely access your openHAB's web interface go to <code>https://myopenhab.org/openhab.app?sitemap=yoursitemapname</code>
+                                You are using openHAB 1.x. To remotely access your openHAB's web interface go to <code><%=baseurl%>/openhab.app?sitemap=yoursitemapname</code>
                 <%
                             }
                             break;


### PR DESCRIPTION
Currently only the host, port and protocol information, which are accessible
through the provided getter functions, but it can provide access to other
configurations and settings, too.

This improves the handling of the host, port and protocol part of a base url,
which was currently handled by a single configuration variable, only. With this
it was unclear, what the configuration holds and what is expected (with protocol,
or without, with port or without, and so on). The configuration also slightly
changed. The system object know provides a separate way for specifying the base
url with the new options:
 - protocol: The protocol of the "public" accessible URL for this service (e.g. http
   or https)
 - host: The host- or domain name from which this service is accesible, e.g. localhost
   or example.com
 - port: The port over which this service is accesible, e.g. 80 or 443.

This also fixes #45 by using the new getBaseURL() method of the System class to retrieve
the base url of the service and appends the path to that, instead of a hard-coded URL.