### PR TITLE
Expose configured public Google Cloud Messaging settings

### DIFF
--- a/app.js
+++ b/app.js
@@ -19,7 +19,11 @@
 // TODO: Move all request handlers out of here, move authentication to auth.js
 
 // Main Logging setup
-var logger = require('./logger.js');
+var logger = require('./logger.js'),
+    config = require('./config.json'),
+    system = require('./system');
+
+system.setConfiguration(config);
 
 require('heapdump');
 
@@ -33,10 +37,9 @@ logger.info('openHAB-cloud: Backend logging initialized...');
 
 // Initialize the main configuration
 var taskEnv = process.env.TASK || 'main';
-var config = require('./config.json');
 
 // If Google Cloud Messaging is configured set it up
-if (config.gcm) {
+if (system.isGcmConfigured()) {
     require('./gcm-xmpp');
 }
 
@@ -73,10 +76,7 @@ var flash = require('connect-flash'),
     appleSender = require('./aps-helper'),
     oauth2 = require('./oauth2'),
     auth = require('./auth.js'),
-    Limiter = require('ratelimiter'),
-    system = require('./system');
-
-system.setConfiguration(config);
+    Limiter = require('ratelimiter');
 
 // Setup Google Cloud Messaging component
 var gcm = require('node-gcm');
@@ -806,6 +806,7 @@ app.all('/habpanel/*', ensureRestAuthenticated, preassembleBody, setOpenhab, pro
 
 // myOH API for mobile apps
 app.all('/api/v1/notifications*', ensureRestAuthenticated, preassembleBody, setOpenhab, api_routes.notificationsget);
+app.all('/api/v1/settings/notifications', ensureRestAuthenticated, preassembleBody, setOpenhab, api_routes.notificationssettingsget);
 
 // Android app registration
 app.all('/addAndroidRegistration*', ensureRestAuthenticated, preassembleBody, setOpenhab, addAndroidRegistration);

--- a/gcm-xmpp.js
+++ b/gcm-xmpp.js
@@ -1,4 +1,4 @@
-var config = require('./config.json');
+var system = require('./system');
 
 /*
  This module maintains XMPP connection to GCM to receive messages from Android
@@ -11,8 +11,8 @@ var UserDevice = require('./models/userdevice'),
     logger = require('./logger.js'),
     xmppOptions = {
         type: 'client',
-        jid: config.gcm.jid,
-        password: config.gcm.password,
+        jid: system.getGcmJid(),
+        password: system.getGcmPassword(),
         port: 5235,
         host: 'gcm.googleapis.com',
         legacySSL: true,

--- a/routes/api.js
+++ b/routes/api.js
@@ -3,6 +3,7 @@ var Openhab = require('../models/openhab');
 var Notification = require('../models/notification');
 var logger = require('../logger');
 var moment = require('moment');
+var system = require('../system');
 
 exports.notificationsget = function(req, res) {
     var limit = req.param('limit') > 0 ? req.param('limit') : 10,
@@ -22,4 +23,15 @@ exports.notificationsget = function(req, res) {
             });
         }
     });
-}
+};
+
+exports.notificationssettingsget = function(req, res) {
+    var config = {};
+
+    if (system.isGcmConfigured()) {
+        config.gcm = {
+            "senderId": system.getGcmSenderId()
+        };
+    }
+    res.send(config);
+};

--- a/system/index.js
+++ b/system/index.js
@@ -2,6 +2,13 @@ var url = require('url');
 var System = function() {};
 
 /**
+ * The suffix, which is appended to the GCM sender ID to build the full jid.
+ *
+ * @type {string}
+ */
+System.jidSuffix = '@gcm.googleapis.com';
+
+/**
  * Sets the configuration object for this System object which should holf the configuration options for this instance
  * of the app.
  * @param {Object} config
@@ -27,6 +34,17 @@ System.prototype.setConfiguration = function(config) {
         this.config.system.host = parsedUrl.hostname;
         this.config.system.port = parsedUrl.port;
         this.config.system.protocol = (parsedUrl.protocol || 'http:').replace(':', '');
+    }
+
+    // backward-compatibility to jid/senderId setting of GCM
+    if (this.config && this.config.gcm && this.config.gcm.hasOwnProperty('jid')) {
+        var splittedConfig = this.config.gcm.jid.split('@');
+
+        if (splittedConfig.length !== 2) {
+            throw new Error('The Google Cloud Message JID needs to be of format: jid' + System.jidSuffix + ' but got:' +
+                this.config.gcm.jid + '. Can\'t migrate to use sender ID only.');
+        }
+        this.config.gcm.senderId = splittedConfig[0];
     }
 };
 
@@ -93,6 +111,46 @@ System.prototype.getProtocol = function() {
  */
 System.prototype.getBaseURL = function() {
     return this.getProtocol() + '://' + this.getHost() + ':' + this.getPort();
+};
+
+/**
+ * Returns true, if Google Cloud Message seems to be configured, false otherwise.
+ * @return {boolean}
+ */
+System.prototype.isGcmConfigured = function() {
+    try {
+        this.getGcmSenderId();
+        return true;
+    } catch(e) {
+        return false;
+    }
+}
+
+/**
+ * Returns the sender ID of GCM, if it exists, throws an error otherwise.
+ *
+ * @return {*}
+ */
+System.prototype.getGcmSenderId = function() {
+    return this.getConfig(['gcm', 'senderId']);
+};
+
+/**
+ * Returns the JID used to login to GCM services, if the sender ID is set. Throws an error otherwise.
+ *
+ * @return {string}
+ */
+System.prototype.getGcmJid = function() {
+    return this.getGcmSenderId() + System.jidSuffix;
+};
+
+/**
+ * Returns the configured pssword for GCM for the configured sender ID. If it isn't set, it throws an error.
+ *
+ * @return {*}
+ */
+System.prototype.getGcmPassword = function() {
+    return this.getConfig(['gcm', 'password']);
 };
 
 module.exports = new System();

--- a/tests/qunit/system/index.js
+++ b/tests/qunit/system/index.js
@@ -7,7 +7,7 @@ var system = require('../../../system'),
         }
     };
 
-QUnit.module("System");
+QUnit.module('System');
 
 QUnit.test('Requiring twice returns same object', function (assert) {
     var requireSecond = require('../../../system');
@@ -43,6 +43,54 @@ QUnit.test('Using baseurl without protocol works correctly', function (assert) {
     assert.equal(system.getHost(), 'example.com');
     assert.equal(system.getPort(), '3000');
     assert.equal(system.getProtocol(), 'http');
+});
+
+QUnit.test('Using gcm.jid works for sender ID', function (assert) {
+    var exampleConfig = Object.assign({}, globalExampleConfig);
+    exampleConfig.gcm = {
+        'jid': '123456@gcm.googleapis.com',
+        'password': '1234'
+    };
+
+    system.setConfiguration(exampleConfig);
+
+    assert.equal(system.isGcmConfigured(), true);
+    assert.equal(system.getGcmSenderId(), '123456');
+    assert.equal(system.getGcmJid(), '123456@gcm.googleapis.com');
+});
+
+QUnit.test('Using gcm.senderId works', function (assert) {
+    var exampleConfig = Object.assign({}, globalExampleConfig);
+    exampleConfig.gcm = {
+        'senderId': '123456',
+        'password': '1234'
+    };
+
+    system.setConfiguration(exampleConfig);
+
+    assert.equal(system.isGcmConfigured(), true);
+    assert.equal(system.getGcmSenderId(), '123456');
+    assert.equal(system.getGcmJid(), '123456@gcm.googleapis.com');
+});
+
+QUnit.test('#isGcmConfigured', function (assert) {
+    system.setConfiguration(globalExampleConfig);
+
+    assert.equal(system.isGcmConfigured(), false);
+});
+
+QUnit.test('#getGcmJid, #getGcmSenderId, #getGcmPassword', function (assert) {
+    var exampleConfig = Object.assign({}, globalExampleConfig);
+    exampleConfig.gcm = {
+        'senderId': '123456',
+        'password': '1234'
+    };
+
+    system.setConfiguration(exampleConfig);
+
+    assert.equal(system.getGcmSenderId(), '123456');
+    assert.equal(system.getGcmJid(), '123456@gcm.googleapis.com');
+    assert.equal(system.getGcmPassword(), '1234');
 });
 
 QUnit.test('#getHost()', function (assert) {


### PR DESCRIPTION
This commit adds a new api endpoint, which will expose the google cloud
messaging sender ID which is needed to enable push notifications with
the app.

The sender ID can differ between openHAB-cloud instances, which makes the
implementation in the app a bit more difficult, therefore this endpoint is
a pre-step to make the app's push notification more dynamic.