### PR TITLE
Fix caching issue for authentication of users

### DIFF
--- a/models/user.js
+++ b/models/user.js
@@ -86,7 +86,9 @@ UserSchema.static('registerToAccount', function(username, password, account, rol
 });
 
 UserSchema.static('authenticate', function (username, password, callback) {
-    this.findOne({ username: username }).cache().exec(function(err, user) {
+    // don't use cache() here, before a proper way to invalidate the cache when, e.g., the password is changed is
+    // implemented. See also: https://github.com/Gottox/mongoose-cache/issues/17
+    this.findOne({ username: username }).exec(function(err, user) {
         if (err)
             return callback(err, false, {message: 'Authentication error'});
         if (!user)


### PR DESCRIPTION
Using cache() for the authenticate function probably speeds up the query,
as cached results will be returned, however, this will result in problems,
when the user cahnged his password. Due to the cache of the query results,
the password is cached, too, and therefore, for a specific amount of time,
or until the app is restarted, the old password will be valid for login,
and not the new one.

Fix this by not caching the query of users for now, until a proper way for
cache invalidation is implemented in mongoose-cache.

Fixes #92

Signed-off-by: Florian Schmidt <florian.schmidt.welzow@t-online.de>