### PR TITLE
Handle undefined, null and falsy values in socket.io requests

### DIFF
--- a/app.js
+++ b/app.js
@@ -1004,7 +1004,7 @@ io.sockets.on('connection', function (socket) {
     socket.on('response', function (data) {
         var self = this;
         var requestId = data.id;
-        if (restRequests[requestId] !== null) {
+        if (restRequests[requestId]) {
             if (self.handshake.uuid === restRequests[requestId].openhab.uuid) {
                 // self.to(self.handshake.uuid).emit('response', data);
                 if (data.error !== null) {
@@ -1028,7 +1028,7 @@ io.sockets.on('connection', function (socket) {
     socket.on('responseHeader', function (data) {
         var self = this;
         var requestId = data.id;
-        if (restRequests[requestId] !== null) {
+        if (restRequests[requestId]) {
             if (self.handshake.uuid === restRequests[requestId].openhab.uuid && !restRequests[requestId].headersSent) {
                 restRequests[requestId].writeHead(data.responseStatusCode, data.responseStatusText, data.headers);
             } else {
@@ -1044,7 +1044,7 @@ io.sockets.on('connection', function (socket) {
     socket.on('responseContent', function (data) {
         var self = this;
         var requestId = data.id;
-        if (restRequests[requestId] !== null) {
+        if (restRequests[requestId]) {
             if (self.handshake.uuid === restRequests[requestId].openhab.uuid) {
                 restRequests[requestId].write(new Buffer(data.body, 'base64'));
             } else {
@@ -1060,7 +1060,7 @@ io.sockets.on('connection', function (socket) {
     socket.on('responseContentBinary', function (data) {
         var self = this;
         var requestId = data.id;
-        if (restRequests[requestId] !== null) {
+        if (restRequests[requestId]) {
             if (self.handshake.uuid === restRequests[requestId].openhab.uuid) {
                 restRequests[requestId].write(data.body);
             } else {
@@ -1075,7 +1075,7 @@ io.sockets.on('connection', function (socket) {
     socket.on('responseFinished', function (data) {
         var self = this;
         var requestId = data.id;
-        if (restRequests[requestId] !== null) {
+        if (restRequests[requestId]) {
             if (self.handshake.uuid === restRequests[requestId].openhab.uuid) {
                 // self.to(self.handshake.uuid).emit('responseFinished', data);
                 restRequests[requestId].end();
@@ -1087,7 +1087,7 @@ io.sockets.on('connection', function (socket) {
     socket.on('responseError', function (data) {
         var self = this;
         var requestId = data.id;
-        if (restRequests[requestId] !== null) {
+        if (restRequests[requestId]) {
             if (self.handshake.uuid === restRequests[requestId].openhab.uuid) {
                 // self.to(self.handshake.uuid).emit('responseError', data);
                 restRequests[requestId].send(500, data.responseStatusText);


### PR DESCRIPTION
Checking for null makes sure, that a variable with a null value will not be used to access a property on it, however, there're
other values, where an access to a specific value will result in errors, such as undefined or other falsy values. Therefore,
all checks for null were changed to checks for a falsy value instead to cover more error cases (such as undefined).

Fixes #95