### PR TITLE
Float the "send message" container to the right

### DIFF
--- a/public/css/layout.css
+++ b/public/css/layout.css
@@ -1069,6 +1069,9 @@ nav#projectsNav ul li a {
 #projectsNavAlt  ul li a:hover{text-decoration:none;}
 /* single project v2 */
 
+#deviceSendMessage {
+    float: right;
+}
 
 
 section#projectImages {

--- a/uncss.js
+++ b/uncss.js
@@ -1,0 +1,15 @@
+var uncss = require('uncss');
+
+var files   = ['http://localhost:3000'],
+    options = {
+        ignoreSheets : [/bootstrap/],
+    };
+
+uncss(files, options, function (error, output) {
+    console.log(output);
+});
+
+/* Look Ma, no options! */
+uncss(files, function (error, output) {
+    console.log(output);
+});

--- a/views/devices.ejs
+++ b/views/devices.ejs
@@ -63,8 +63,8 @@
                     </table>
                     <% } %>
                 </div>
-                <div class="span9">
-                    <% if (userDevices.length > 0 ) { %>
+                <% if (userDevices.length > 0 ) { %>
+                <div class="span9" id="deviceSendMessage">
                     <h3>Send a message to this device</h3>
                     <div class="divider"><span></span></div>
                     <form method="post" action="/devices/<%=userDevices[selectedDeviceArrayId].id%>/sendmessage">
@@ -72,8 +72,8 @@
                         <textarea id="messagetext" name="messagetext" maxlength="250" rows="4"></textarea>
                         <button type="submit" class="btn">Send message</button>
                     </form>
-                    <% } %>
                 </div>
+                <% } %>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Otherwise, the container will be displayed directly under the aside navigation
container, if it hasn't enough items to "move" the "send message" container
to the right. This is inconsistent behaviour dependant on the number of devices
the user has registered.

With the float to right, the "send message" container is always visible on the
right side of the page.