### PR TITLE
Fixes legal, T&Cs error message when registrations is enabled, nodemailer update and year correction

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "morgan": "^1.8.2",
     "node-gcm": "0.14.4",
     "node-xmpp": "1.0.8",
-    "nodemailer": "0.5.2",
+    "nodemailer": "4.0.1",
     "oauth2orize": "1.0.1",
     "passport": "0.1.18",
     "passport-http": "0.2.2",

--- a/system/index.js
+++ b/system/index.js
@@ -131,8 +131,9 @@ System.prototype.isUserRegistrationEnabled = function() {
  * @return {boolean}
  */
 System.prototype.hasLegalTerms = function() {
-    try {
-        return this.getConfig(['legal', 'terms']) !== false;
+	let config = this.getConfig(['legal', 'terms']);
+	try {
+        return ((config !== false) && (config !== ""));
     } catch (err) {
         return false;
     }
@@ -144,8 +145,9 @@ System.prototype.hasLegalTerms = function() {
  * @return {boolean}
  */
 System.prototype.hasLegalPolicy = function() {
-    try {
-        return this.getConfig(['legal', 'policy']) !== false;
+	let config = this.getConfig(['legal', 'policy']);
+	try {
+		return ((config !== false) && (config !== ""));
     } catch (err) {
         return false;
     }

--- a/views/footer.ejs
+++ b/views/footer.ejs
@@ -4,7 +4,7 @@
        <div class="container">
            <div class="row">
                <div class="span12" align="center">
-                   <p>Copyright © 2016 by the <a class="inversedlink" href="https://github.com/openhab">openHAB Community</a> and the <a class="inversedlink" href="http://www.openhabfoundation.org/">openHAB Foundation</a></p>
+                   <p>Copyright © 2017 by the <a class="inversedlink" href="https://github.com/openhab">openHAB Community</a> and the <a class="inversedlink" href="http://www.openhabfoundation.org/">openHAB Foundation</a></p>
                </div>
            </div>
        </div>


### PR DESCRIPTION
- This fixes the problem that was introduced after the latest refactorings, where the check for 
legal and T&Cs was only done on the to config params, but the check for Strings was removed.

- Updates the deprecated nodemailer module to latest version

- Corrects the year in the footer (since I had git problems, need to re add it)