### PR TITLE
Let mongod bind on other IPs than localhost

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
         build: 
            context: ./
            dockerfile: ./docker/mongo/Dockerfile
-        command: mongod --smallfiles
+        command: mongod --smallfiles --bind_ip_all
         networks:
         - ohcloud-network
         ports:


### PR DESCRIPTION
Starting from MongoDB 3.6 mongod is only binding to localhost by default (see [https://docs.mongodb.com/manual/release-notes/3.6-compatibility/](url)).
To make this still work with docker-compose I added the parameter `--bind_ip_all` to restore the former behaviour.