### PR TITLE
Add severity, icon and timestamp to notifications.

### DIFF
--- a/app.js
+++ b/app.js
@@ -383,20 +383,27 @@ function sendNotificationToUser(user, message, icon, severity) {
         }
         // If we found any android devices, send notification
         if (androidRegistrations.length > 0) {
-            firebase.sendNotification(androidRegistrations, message);
+            firebase.sendNotification(androidRegistrations, newNotification);
         }
         // If we found any ios devices, send notification
         if (iosDeviceTokens.length > 0) {
-            sendIosNotifications(iosDeviceTokens, message);
+            sendIosNotifications(iosDeviceTokens, newNotification);
         }
     });
 }
 
-function sendIosNotifications(iosDeviceTokens, message) {
+function sendIosNotifications(iosDeviceTokens, notification) {
+    if (!config.apn) {
+        return;
+    }
+    var payload = {
+        severity: notification.severity,
+        icon: notification.icon,
+        persistedId: notification._id,
+        timestamp: notification.created.getTime()
+    };
     for (var i = 0; i < iosDeviceTokens.length; i++) {
-        if (config.apn) {
-            appleSender.sendAppleNotification(iosDeviceTokens[i], message);
-        }
+        appleSender.sendAppleNotification(iosDeviceTokens[i], notification.message, payload);
     }
 }
 

--- a/notificationsender/aps-helper.js
+++ b/notificationsender/aps-helper.js
@@ -37,9 +37,9 @@ module.exports.test = function (deviceToken) {
     apnConnection.pushNotification(note, myDevice);
 }
 
-module.exports.sendAppleNotification = function (deviceToken, message) {
+module.exports.sendAppleNotification = function (deviceToken, message, payload) {
     var myDevice = new apn.Device(deviceToken);
-    var note = new apn.Notification();
+    var note = new apn.Notification(payload);
     note.expiry = Math.floor(Date.now() / 1000) + 3600; // Expires 1 hour from now.
     note.badge = 0;
     note.sound = 'ping.aiff';

--- a/notificationsender/firebase.js
+++ b/notificationsender/firebase.js
@@ -4,7 +4,8 @@ const logger = require('../logger.js');
 const firebaseClient = new Firebase(system.getGcmPassword());
 
 const firebaseOptions = {
-    delay_while_idle: false
+    delay_while_idle: false,
+    prority: 'high'
 };
 
 function sendNotificationWithData(registrationIds, data) {

--- a/notificationsender/firebase.js
+++ b/notificationsender/firebase.js
@@ -7,23 +7,39 @@ const firebaseOptions = {
     delay_while_idle: false
 };
 
-exports.sendNotification = function(registrationIds, message) {
+function sendNotificationWithData(registrationIds, data) {
     redis.incr("androidNotificationId", function(error, androidNotificationId) {
         if (error) {
             return;
         }
 
-        const data = {
-            type: 'notification',
-            notificationId: androidNotificationId,
-            message: message,
-        };
+        data.type = 'notification';
+        data.notificationId = androidNotificationId;
         firebaseClient.message(registrationIds, data, firebaseOptions, function (result) {
             if (result.failure) {
                 logger.error("openHAB-cloud: GCM send error: " + JSON.stringify(result));
             }
         });
     });
+};
+
+exports.sendMessageNotification = function(registrationIds, message) {
+    var data = {
+        message: message,
+        timestamp: Date.now()
+    };
+    sendNotificationWithData(registrationIds, data);
+};
+
+exports.sendNotification = function(registrationIds, notification) {
+    var data = {
+        message: notification.message,
+        severity: notification.severity,
+        icon: notification.icon,
+        persistedId: notification._id,
+        timestamp: notification.created.getTime()
+    };
+    sendNotificationWithData(registrationIds, data);
 };
 
 exports.hideNotification = function(registrationIds, notificationId) {

--- a/routes/devices.js
+++ b/routes/devices.js
@@ -64,7 +64,7 @@ exports.devicessendmessage = function(req, res) {
                     appleSender.sendAppleNotification(sendMessageDevice.iosDeviceToken, message);
                 }
                 if (sendMessageDevice.deviceType == 'android') {
-                    firebase.sendNotification(sendMessageDevice.androidRegistration, message);
+                    firebase.sendMessageNotification(sendMessageDevice.androidRegistration, message);
                 }
                 req.flash('info', 'Your message was sent');
                 res.redirect('/devices/' + sendMessageDevice._id);


### PR DESCRIPTION
Additionally, also send the database ID of the notification, which
allows matching it against the result of the 'get notifications' API
call.

Closes #160