### PR TITLE
Updated docker-compose and dockerization of openHAB-cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,10 +233,10 @@ to spin up the dockerized openhab-cloud backend.
 #### Architecture
 The dockerized openhab-cloud uses a separate docker image and container for each part of the overall system
 according to the following stack:
-* app-1: node.js and express.js (alpine-node:7.5)
-* mongodb: MongoDB database (mongo:3)
-* nginx: nginx proxy (nginx)
-* redis: redis session manager (redis:alpine)
+* app-1: node.js and express.js (openhab/openhab-cloud/app-1:latest)
+* mongodb: MongoDB database (bitnami/mongodb:latest)
+* nginx: nginx proxy (openhab/openhab-cloud/nginx:latest)
+* redis: redis session manager (bitnami/redis:latest)
 
 #### Prerequisites
 To run openhab-cloud make sure docker, docker-machine and docker-compose are installed on your machine.
@@ -260,6 +260,16 @@ container services of docker-compose:
 ```
 
 To change the server IP/DNS matching your installation, please refer to [Setting up Nginx](#setupNginx)
+
+#### Customization
+
+If you want to customize the openhab-cloud app or change e.g. configurations within ```config.json```,
+you need to switch to the local build of the node app. Adjust the build stratgy in the ```docker-compose.yml```
+and replace the ```image``` section of ```docker-compose.yml``` with the following lines, to not use the official docker hub images anymore and switch to your local sources as base for the app-1 image:
+
+```build: 
+  context: ./
+  dockerfile: ./docker/node/Dockerfile```
 
 #### Run
 To create and run the composed application, use the following command: 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 services:
     app-1:
         container_name: app-1
-        image: docker.io/homeix/app-1:latest
+        image: docker.io/openhab/openhabcloud-app
         volumes:
         - app-1:/opt/openhabcloud
         working_dir: /opt/openhabcloud
@@ -41,7 +41,7 @@ services:
         restart: always
     nginx:
         container_name: nginx
-        image: docker.io/homeix/nginx:latest
+        image: docker.io/openhab/openhabcloud-nginx
         volumes:
         - app-1:/opt/openhabcloud
         networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,55 +1,58 @@
-version: '2'
+version: '3'
 services:
     app-1:
         container_name: app-1
-        build: 
-           context: ./
-           dockerfile: ./docker/node/Dockerfile
+        image: docker.io/homeix/app-1:latest
         volumes:
-        - /opt/openhabcloud
+        - app-1:/opt/openhabcloud
+        working_dir: /opt/openhabcloud
         networks:
         - ohcloud-network
         links:
         - mongodb
         - redis
         ports:
-        - "3000"     
+        - "3000"
+        depends_on:
+        - mongodb
+        - redis  
         restart: always     
     mongodb:
         container_name: mongodb
-        build: 
-           context: ./
-           dockerfile: ./docker/mongo/Dockerfile
+        image: bitnami/mongodb:latest
         command: mongod --smallfiles --bind_ip_all
         networks:
         - ohcloud-network
         ports:
         - "27017"
+        volumes:
+        - /data/db
+        - /data/configdb
         restart: always
     redis:
         container_name: redis
-        build: 
-           context: ./
-           dockerfile: ./docker/redis/Dockerfile
+        image: bitnami/redis:latest
         networks:
         - ohcloud-network
         ports:
         - "6379"
+        environment:
+        - REDIS_PASSWORD=123_openHAB
         restart: always
     nginx:
         container_name: nginx
-        build: 
-           context: ./
-           dockerfile: ./docker/nginx/Dockerfile
+        image: docker.io/homeix/nginx:latest
+        volumes:
+        - app-1:/opt/openhabcloud
         networks:
         - ohcloud-network
         ports:
-        - "80:80"
-        - "443:443"
+        - "80:8081"
+        - "443:8443"
         links:
         - app-1:app-1
-        volumes_from:
-        - app-1
+volumes:
+  app-1:
 networks:
   ohcloud-network:
     driver: bridge

--- a/docker/mongo/Dockerfile
+++ b/docker/mongo/Dockerfile
@@ -1,4 +1,0 @@
-FROM mongo:3
-
-# File Author / Maintainer
-MAINTAINER Mehmet Arziman

--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -1,8 +1,8 @@
 # Set nginx base image
-FROM nginx
+FROM bitnami/nginx
 
 # File Author / Maintainer
 MAINTAINER Mehmet Arziman
 
 # Copy custom configuration file from the current directory
-COPY ./docker/nginx/nginx.conf /etc/nginx/nginx.conf
+COPY ./docker/nginx/openhabcloud_nginx.conf /bitnami/nginx/conf/vhosts/my_vhost.conf

--- a/docker/nginx/openhabcloud_nginx.conf
+++ b/docker/nginx/openhabcloud_nginx.conf
@@ -1,25 +1,16 @@
-worker_processes 4;
-
-events { worker_connections 1024; }
-
-http {
-	
-	include /etc/nginx/mime.types;
-	
-	upstream app_server {
+upstream app_server {
 		server app-1:3000 fail_timeout=5s max_fails=5;
 	}
 	
-	server {
-		listen 80 default_server;
-		listen [::]:80 default_server;
+server{
+		listen 0.0.0.0:8081;
 		
 		charset utf-8;
-		
-		access_log /var/log/nginx/openhab.org-access.log;
-		error_log /var/log/nginx/openhab.org-error.log;
-		client_max_body_size 300m;
-		
+
+		access_log "/opt/bitnami/nginx/logs/openhabcloud-access.log";
+    	error_log "/opt/bitnami/nginx/logs/openhabcloud-error.log";
+    	client_max_body_size 300m;
+
 		root /opt/openhabcloud;
 		
 		location ~ /.well-known {
@@ -69,7 +60,5 @@ http {
 			proxy_set_header Host $host;
 			proxy_set_header X-Real-IP $remote_addr ;
 			proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-		}
-	
-	}
+		}	
 }

--- a/docker/nginx/openhabcloud_nginx.conf
+++ b/docker/nginx/openhabcloud_nginx.conf
@@ -6,10 +6,10 @@ server{
 		listen 0.0.0.0:8081;
 		
 		charset utf-8;
-
+		
 		access_log "/opt/bitnami/nginx/logs/openhabcloud-access.log";
-    	error_log "/opt/bitnami/nginx/logs/openhabcloud-error.log";
-    	client_max_body_size 300m;
+		error_log "/opt/bitnami/nginx/logs/openhabcloud-error.log";
+		client_max_body_size 300m;
 
 		root /opt/openhabcloud;
 		

--- a/docker/node/Dockerfile
+++ b/docker/node/Dockerfile
@@ -28,15 +28,13 @@ RUN rm -rf \
     /usr/lib/node_modules/npm/html \
     /usr/lib/node_modules/npm/scripts
 
-# We going to use changes to package.json to force Docker not to use the cache
-# when we change our app nodejs dependencies:
-COPY ./package.json ./config.json /tmp/
-
-RUN cd /tmp && npm install && npm rebuild bcrypt --build-from-source
-RUN mkdir -p /opt/openhabcloud && cp -a /tmp/node_modules /opt/openhabcloud
-
-# From here we load our application's code in, therefore the previous docker
-# "layer" thats been cached will be used if possible
+RUN mkdir -p /opt/openhabcloud 
+COPY ./package.json ./config.json /opt/openhabcloud/
+RUN mkdir /data
+RUN ln -s /opt/openhabcloud/package.json /data
+WORKDIR /data
+RUN npm install && npm rebuild bcrypt --build-from-source
+ENV NODE_PATH /data/node_modules
 WORKDIR /opt/openhabcloud
 
 USER openhabcloud
@@ -44,5 +42,4 @@ USER openhabcloud
 ADD . /opt/openhabcloud
 
 EXPOSE 3000
-
-CMD ["node", "/opt/openhabcloud/app.js"]
+CMD ["node", "app.js"]

--- a/docker/redis/Dockerfile
+++ b/docker/redis/Dockerfile
@@ -1,4 +1,0 @@
-FROM redis:alpine 
-
-# File Author / Maintainer
-MAINTAINER Mehmet Arziman

--- a/views/applications.ejs
+++ b/views/applications.ejs
@@ -45,7 +45,7 @@
                                 <%= date_util(oauth2tokens[i].created, timeZone).calendar() %>
                             </td>
                             <td>
-                                <a href="<% oauth2tokens[i].oAuthClient.homeUrl %>"><img style="height: 24px;" src="/img/oauth2/<%= oauth2tokens[i].oAuthClient.icon %>"><%= oauth2tokens[i].oAuthClient.name %></a>
+                                <a href="<% oauth2tokens[i].oAuthClient.homeUrl %>"><img style="height: 24px;" src="/img/oauth2/<%= oauth2tokens[i].oAuthClient.icon %>">&nbsp;<%= oauth2tokens[i].oAuthClient.name %></a>
                             </td>
                             <td>
                                 <%= oauth2tokens[i].oAuthClient.description %>


### PR DESCRIPTION
This PR makes the dockerized version of openHAB-cloud more easy to spin up and
uses the officially hosted openhab/openhabcloud images from docker hub.