### PR TITLE
IFTTT integration: Listen to all item events if no itemStatus is defined within the trigger

### DIFF
--- a/routes/ifttt.js
+++ b/routes/ifttt.js
@@ -196,7 +196,11 @@ exports.v1triggeritemstate = [
                 Item.findOne({openhab: openhab._id, name: itemName}, function (error, item) {
                     if (!error && item) {
                         if (eventLimit > 0) {
-                            Event.find({openhab: openhab._id, source: item.name, status: itemStatus})
+                            var eventFilters = {openhab: openhab._id, source: item.name};
+                            if(itemStatus != undefined && itemStatus.length > 0) {
+                                eventFilters["status"] = itemStatus;
+                            }
+                            Event.find(eventFilters)
                                 .sort({when: 'desc'})
                                 .limit(eventLimit)
 				.lean()


### PR DESCRIPTION
This change should make it possible listening to all item changes without being forced to filter the listener events. This can be done now with leaving the field "Changes to" / itemStatus empty.

To be honest, I have no test environment to test this, but I did the change very carefully to the best of my knowledge.

Use case: https://community.openhab.org/t/trigger-an-ifttt-action-always-when-an-item-changes/43017

Signed-off-by: Patrick Fink <mail@pfink.de>