### PR TITLE
Escape username to use inside RegExp

### DIFF
--- a/models/user.js
+++ b/models/user.js
@@ -85,10 +85,14 @@ UserSchema.static('registerToAccount', function(username, password, account, rol
     });
 });
 
+function escapeRegExp(string) {
+  return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
+}
+
 UserSchema.static('authenticate', function (username, password, callback) {
     // don't use cache() here, before a proper way to invalidate the cache when, e.g., the password is changed is
     // implemented. See also: https://github.com/Gottox/mongoose-cache/issues/17  
-	this.findOne({ username: { $regex: new RegExp("^" + username.toLowerCase(), "i") } }).exec(function(err, user) {
+	this.findOne({ username: { $regex: new RegExp("^" + escapeRegExp(username.toLowerCase()), "i") } }).exec(function(err, user) {
         if (err)
             return callback(err, false, {message: 'Authentication error'});
         if (!user)


### PR DESCRIPTION
As the usernames are email addresses and valid email addresses can contain almost any character they should be escaped before they are used in a regular expression.

Some users (like me) use a '+' inside their email to denote subaddresses (like 'kandre+fishysite@ak-online.be'), which makes sorting and dropping mails for specific addresses easier, essentially creating infinite amounts of throwaway email addresses.
Unfortunately the '+' sign also has a special meaning in regular expressions, so the '/^kandre+openhab@ak-online.be/i' will never match the string 'kandre+openhab@ak-online.be'.

This problem has been seen by myself and others, hence this fixes #202.

This pull request escapes the username before using it in the regular expression, using the example 'escapeRegExp()' function provided in the MDN (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions).

Please note that I did not have the possibility to test this, and this change might as well violate any style. It is mainly provided as a way demonstrate a possible solution to the issue #202.

Signed-off-by: Andre Klärner <kandre@ak-online.be> (github: klaernie)