### PR TITLE
Fix paging parameter (page/skip/limit) handling.

### DIFF
--- a/routes/api.js
+++ b/routes/api.js
@@ -6,8 +6,8 @@ var moment = require('moment');
 var system = require('../system');
 
 exports.notificationsget = function(req, res) {
-    var limit = req.query.limit > 0 ? req.query.limit : 10,
-    skip = req.query.skip > 0 ? req.query.skip : 0;
+    var limit = req.query.limit > 0 ? parseInt(req.query.limit) : 10,
+    skip = req.query.skip > 0 ? parseInt(req.query.skip) : 0;
     Notification.find({user: req.user.id}, '-user')
         .limit(limit)
         .skip(skip)

--- a/routes/api.js
+++ b/routes/api.js
@@ -6,8 +6,8 @@ var moment = require('moment');
 var system = require('../system');
 
 exports.notificationsget = function(req, res) {
-    var limit = req.params.limit > 0 ? req.params.limit : 10,
-    skip = req.params.skip > 0 ? req.params.skip : 0;
+    var limit = req.query.limit > 0 ? req.query.limit : 10,
+    skip = req.query.skip > 0 ? req.query.skip : 0;
     Notification.find({user: req.user.id}, '-user')
         .limit(limit)
         .skip(skip)

--- a/routes/events.js
+++ b/routes/events.js
@@ -6,12 +6,12 @@ var moment = require('moment');
 
 exports.eventsget = function(req, res) {
     var perPage = 20,
-        page = req.params.page > 0 ? req.params.page : 0;
+        page = req.query.page > 0 ? req.query.page : 0;
     req.user.openhab(function(error, openhab) {
         if (!error && openhab != null) {
             var filter = {openhab: openhab};
-            if (req.params.source)
-                filter.source = req.params.source;
+            if (req.query.source)
+                filter.source = req.query.source;
             Event.find(filter)
                 .limit(perPage)
                 .skip(perPage * page)
@@ -20,7 +20,7 @@ exports.eventsget = function(req, res) {
                 .exec(function(error, events) {
                     Event.count().exec(function (err, count) {
                         res.render('events', { events: events, pages: count / perPage, page: page,
-                            title: "Events", user: req.user, openhab: openhab, source: req.params.source,
+                            title: "Events", user: req.user, openhab: openhab, source: req.query.source,
                             errormessages:req.flash('error'), infomessages:req.flash('info') });
                     });
                 });
@@ -33,7 +33,7 @@ exports.eventsget = function(req, res) {
 exports.eventsvaluesget = function(req, res) {
     req.user.openhab(function(error, openhab) {
         if (!error && openhab != null) {
-            var filter = {openhab: openhab, source: req.params.source};
+            var filter = {openhab: openhab, source: req.query.source};
             Event.find(filter).sort({when: 'asc'}).select('when status -_id').exec(function(error, events) {
                 if (!error) {
                     var result = [];

--- a/routes/events.js
+++ b/routes/events.js
@@ -6,7 +6,7 @@ var moment = require('moment');
 
 exports.eventsget = function(req, res) {
     var perPage = 20,
-        page = req.query.page > 0 ? req.query.page : 0;
+        page = req.query.page > 0 ? parseInt(req.query.page) : 0;
     req.user.openhab(function(error, openhab) {
         if (!error && openhab != null) {
             var filter = {openhab: openhab};

--- a/routes/items.js
+++ b/routes/items.js
@@ -3,7 +3,7 @@ var Openhab = require('../models/openhab');
 var Item = require('../models/item');
 
 exports.itemsget = function(req, res) {
-    switch (req.params.sort) {
+    switch (req.query.sort) {
         default:
         case "name":
             var sortValue = {name: 'asc'};

--- a/routes/notifications.js
+++ b/routes/notifications.js
@@ -6,7 +6,7 @@ var moment = require('moment');
 
 exports.notificationsget = function(req, res) {
     var perPage = 20,
-        page = req.query.page > 0 ? req.query.page : 0;
+        page = req.query.page > 0 ? parseInt(req.query.page) : 0;
     req.user.openhab(function(error, openhab) {
         if (!error && openhab != null) {
             var filter = {user: req.user.id};

--- a/routes/notifications.js
+++ b/routes/notifications.js
@@ -6,7 +6,7 @@ var moment = require('moment');
 
 exports.notificationsget = function(req, res) {
     var perPage = 20,
-        page = req.params.page > 0 ? req.params.page : 0;
+        page = req.query.page > 0 ? req.query.page : 0;
     req.user.openhab(function(error, openhab) {
         if (!error && openhab != null) {
             var filter = {user: req.user.id};

--- a/routes/staff.js
+++ b/routes/staff.js
@@ -9,7 +9,7 @@ var redis = require('../redis-helper');
 
 exports.staffget = function(req, res) {
     var perPage = 20,
-        page = req.query.page > 0 ? req.query.page : 0;
+        page = req.query.page > 0 ? parseInt(req.query.page) : 0;
     req.user.openhab(function(error, openhab) {
         if (!error && openhab != null) {
             var filter = {invited: null};
@@ -78,7 +78,7 @@ exports.processenroll = function(req, res) {
 
 exports.invitationsget = function(req, res) {
     var perPage = 20,
-        page = req.query.page > 0 ? req.query.page : 0;
+        page = req.query.page > 0 ? parseInt(req.query.page) : 0;
     req.user.openhab(function(error, openhab) {
         if (!error && openhab != null) {
             if (req.query.hasOwnProperty('email')) {
@@ -142,7 +142,7 @@ exports.deleteinvitation = function(req, res) {
 
 exports.oauthclientsget = function(req, res) {
     var perPage = 20,
-        page = req.query.page > 0 ? req.query.page : 0;
+        page = req.query.page > 0 ? parseInt(req.query.page) : 0;
     req.user.openhab(function(error, openhab) {
         if (!error && openhab != null) {
             OAuth2Client.find()

--- a/routes/staff.js
+++ b/routes/staff.js
@@ -9,7 +9,7 @@ var redis = require('../redis-helper');
 
 exports.staffget = function(req, res) {
     var perPage = 20,
-        page = req.params.page > 0 ? req.params.page : 0;
+        page = req.query.page > 0 ? req.query.page : 0;
     req.user.openhab(function(error, openhab) {
         if (!error && openhab != null) {
             var filter = {invited: null};
@@ -78,7 +78,7 @@ exports.processenroll = function(req, res) {
 
 exports.invitationsget = function(req, res) {
     var perPage = 20,
-        page = req.params.page > 0 ? req.params.page : 0;
+        page = req.query.page > 0 ? req.query.page : 0;
     req.user.openhab(function(error, openhab) {
         if (!error && openhab != null) {
             if (req.query.hasOwnProperty('email')) {
@@ -142,7 +142,7 @@ exports.deleteinvitation = function(req, res) {
 
 exports.oauthclientsget = function(req, res) {
     var perPage = 20,
-        page = req.params.page > 0 ? req.params.page : 0;
+        page = req.query.page > 0 ? req.query.page : 0;
     req.user.openhab(function(error, openhab) {
         if (!error && openhab != null) {
             OAuth2Client.find()


### PR DESCRIPTION
Query parameters are present in req.query, req.params only contains
named parameters that are part of the actual URL.

This re-applies the changes of commit
34a09b6c3e12c6184f29898cdc10ac6e36ff13d3 which were accidentally dropped
in commit cea8d8f7333fdb8bf50d43953eaa0057fb391996.

Closes #222 