### PR TITLE
Fixed basic functionality of pagination for 'Prev' and 'Next'

### DIFF
--- a/views/events.ejs
+++ b/views/events.ejs
@@ -46,11 +46,11 @@
                     <% if (pages > 1) { %>
                     <div class="pagination pagination-centered">
                         <ul>
-                            <li <% if (page == 0) {%>class="disabled"<% } %>> <a href="#"> Prev </a> </li>
+                            <% if (page > 0) { %><li> <a href="?page=<%= page-1 %><% if (source){%>&source=<%=source%><%}%>"> Prev </a> </li><% } %>
                             <% for (var i=0; i <= pages; i++) { %>
                             <li <% if (i == page) {%>class="active"<%}%>> <a href="?page=<%= i %><% if (source){%>&source=<%=source%><%}%>"><%= i+1 %></a> </li>
                             <% } %>
-                            <li <% if (page == pages) { %>class="disabled"<% } %>> <a href="#"> Next </a> </li>
+                            <% if (page < pages) { %><li> <a href="?page=<%= page+1 %><% if (source){%>&source=<%=source%><%}%>"> Next </a> </li><% } %>
                         </ul>
                     </div>
                     <% } %>

--- a/views/notifications.ejs
+++ b/views/notifications.ejs
@@ -45,11 +45,11 @@
                     <% if (pages > 1) { %>
                     <div class="pagination pagination-centered">
                         <ul>
-                            <li <% if (page == 0) {%>class="disabled"<% } %>> <a href="#"> Prev </a> </li>
+                            <% if (page > 0) { %><li> <a href="?page=<%= page-1 %>"> Prev </a> </li><% } %>
                             <% for (var i=0; i <= pages; i++) { %>
                             <li <% if (i == page) {%>class="active"<%}%>> <a href="?page=<%= i %>"><%= i+1 %></a> </li>
                             <% } %>
-                            <li <% if (page == pages) { %>class="disabled"<% } %>> <a href="#"> Next </a> </li>
+                            <% if (page < pages) { %><li> <a href="?page=<%= page+1 %>"> Next </a> </li><% } %>
                         </ul>
                     </div>
                     <% } %>

--- a/views/staff/invitations.ejs
+++ b/views/staff/invitations.ejs
@@ -64,11 +64,11 @@
                     <% if (pages > 1) { %>
                     <div class="pagination pagination-centered">
                         <ul>
-                            <li <% if (page == 0) {%>class="disabled"<% } %>> <a href="#"> Prev </a> </li>
+                            <% if (page > 0) { %><li> <a href="?page=<%= page-1 %>"> Prev </a> </li><% } %>
                             <% for (var i=0; i <= pages; i++) { %>
                             <li <% if (i == page) {%>class="active"<%}%>> <a href="?page=<%= i %>"><%= i+1 %></a> </li>
                             <% } %>
-                            <li <% if (page == pages) { %>class="disabled"<% } %>> <a href="#"> Next </a> </li>
+                            <% if (page < pages) { %><li> <a href="?page=<%= page+1 %>"> Next </a> </li><% } %>
                         </ul>
                     </div>
                     <% } %>

--- a/views/staff/oauthclients.ejs
+++ b/views/staff/oauthclients.ejs
@@ -49,11 +49,11 @@
                     <% if (pages > 1) { %>
                     <div class="pagination pagination-centered">
                         <ul>
-                            <li <% if (page == 0) {%>class="disabled"<% } %>> <a href="#"> Prev </a> </li>
+                            <% if (page > 0) { %><li> <a href="?page=<%= page-1 %>"> Prev </a> </li><% } %>
                             <% for (var i=0; i <= pages; i++) { %>
                             <li <% if (i == page) {%>class="active"<%}%>> <a href="?page=<%= i %>"><%= i+1 %></a> </li>
                             <% } %>
-                            <li <% if (page == pages) { %>class="disabled"<% } %>> <a href="#"> Next </a> </li>
+                            <% if (page < pages) { %><li> <a href="?page=<%= page+1 %>"> Next </a> </li><% } %>
                         </ul>
                     </div>
                     <% } %>

--- a/views/staff/staff.ejs
+++ b/views/staff/staff.ejs
@@ -56,11 +56,11 @@
                     <% if (pages > 1) { %>
                     <div class="pagination pagination-centered">
                         <ul>
-                            <li <% if (page == 0) {%>class="disabled"<% } %>> <a href="#"> Prev </a> </li>
+                            <% if (page > 0) { %><li> <a href="?page=<%= page-1 %>"> Prev </a> </li><% } %>
                             <% for (var i=0; i <= pages; i++) { %>
                             <li <% if (i == page) {%>class="active"<%}%>> <a href="?page=<%= i %>"><%= i+1 %></a> </li>
                             <% } %>
-                            <li <% if (page == pages) { %>class="disabled"<% } %>> <a href="#"> Next </a> </li>
+                            <% if (page < pages) { %><li> <a href="?page=<%= page+1 %>"> Next </a> </li><% } %>
                         </ul>
                     </div>
                     <% } %>


### PR DESCRIPTION
- Fixed basic functionality of pagination for 'Prev' and 'Next'

Follow-up for issue #222 as my https://github.com/openhab/openhab-cloud/issues/222#issuecomment-451107563 was only solved partially.

I guess this is not the final solution because currently we are limited to 6 pages. I can imagine to extend it further. For example to have something similar like over here in GitHub:

![image](https://user-images.githubusercontent.com/5131747/54754729-7d666500-4be4-11e9-8c23-947a6c102c02.png)

Signed-off-by: Christoph Weitkamp <github@christophweitkamp.de>