### PR TITLE
allowed gpstracker paths to skip csrf check

### DIFF
--- a/app.js
+++ b/app.js
@@ -274,7 +274,7 @@ app.use(function (req, res, next) {
 app.use(function (req, res, next) {
     var csrf = csurf();
     // Check if url needs csrf, remote connections and REST connections are excluded from CSRF
-    if (!req.path.match('/rest*') && !req.path.match('/oauth2/token') && !req.path.match('/ifttt/*') && !req.path.match('/remote/*'))
+    if (!req.path.match('/rest*') && !req.path.match('/oauth2/token') && !req.path.match('/ifttt/*') && !req.path.match('/remote/*') && !req.path.match('/gpstracker/*'))
         csrf(req, res, next);
     else
         next();

--- a/routes/index.js
+++ b/routes/index.js
@@ -236,6 +236,7 @@ Routes.prototype.setupProxyRoutes = function (app) {
     app.all('/habmin/*', this.ensureRestAuthenticated, this.preassembleBody, this.setOpenhab, this.ensureServer, this.proxyRouteOpenhab.bind(this));
     app.all('/remote*', this.ensureRestAuthenticated, this.preassembleBody, this.setOpenhab, this.ensureServer, this.proxyRouteOpenhab.bind(this));
     app.all('/habpanel/*', this.ensureRestAuthenticated, this.preassembleBody, this.setOpenhab, this.ensureServer, this.proxyRouteOpenhab.bind(this));
+    app.all('/gpstracker/*', this.ensureRestAuthenticated, this.preassembleBody, this.setOpenhab, this.ensureServer, this.proxyRouteOpenhab.bind(this));
 };
 
 Routes.prototype.setupAppRoutes = function (app) {


### PR DESCRIPTION
Update routing to allow /gpstracker paths to skip CSRF checks. Without this, reporting via OwnTracks apps on the self hosted version of OpenHAB Cloud does not function.

Fixes #231 