### PR TITLE
Only auth to redis with password if set in config

### DIFF
--- a/redis-helper.js
+++ b/redis-helper.js
@@ -5,7 +5,7 @@ var app = require('./app.js'),
     redis = require('redis'),
     redisClient;
 
-logger.info('openHAB-cloud: Connecting ro Redis at ' + app.config.redis.host + ':' + app.config.redis.port);
+logger.info('openHAB-cloud: Connecting to Redis at ' + app.config.redis.host + ':' + app.config.redis.port);
 
 redisClient = redis.createClient(app.config.redis.port, app.config.redis.host);
 
@@ -20,7 +20,7 @@ if (typeof app.config.redis.password !== 'undefined') {
 }
 
 redisClient.on('ready', function () {
-    logger.info('Redis is ready');
+    logger.info('openHAB-cloud: Redis is ready');
 });
 
 redisClient.on('end', function () {

--- a/redis-helper.js
+++ b/redis-helper.js
@@ -8,13 +8,16 @@ var app = require('./app.js'),
 logger.info('openHAB-cloud: Connecting ro Redis at ' + app.config.redis.host + ':' + app.config.redis.port);
 
 redisClient = redis.createClient(app.config.redis.port, app.config.redis.host);
-redisClient.auth(app.config.redis.password, function(error, data) {
-    if (error) {
-        logger.error(error);
-    } else {
-        logger.info('openHAB-cloud: Redis connect response: ' + data);
-    }
-});
+
+if (typeof app.config.redis.password !== 'undefined') {
+    redisClient.auth(app.config.redis.password, function(error, data) {
+        if (error) {
+            logger.error(error);
+        } else {
+            logger.info('openHAB-cloud: Redis connect response: ' + data);
+        }
+    });
+}
 
 redisClient.on('ready', function () {
     logger.info('Redis is ready');


### PR DESCRIPTION
Fixes the error `node_redis: Deprecated: The AUTH command contains a "undefined" argument.` if you remove the redis password from the config as you are running locally