### PR TITLE
OH 3.0 changes

### DIFF
--- a/etc/nginx-openhabcloud-lb-redirects.conf
+++ b/etc/nginx-openhabcloud-lb-redirects.conf
@@ -10,10 +10,10 @@ location @proxy_down {
   proxy_set_header X-Forwarded-Proto https;
   proxy_intercept_errors on;
   recursive_error_pages on;
-  error_page 301 302 307 = @handle_proxy;
+  error_page 307 = @handle_proxy;
 }
 
-#The cloud-director process will send back a 302 with the location of the
+#The cloud-director process will send back a 307 with the location of the
 #server to proxy to which this will follow and proxy the original request
 location @handle_proxy {
   set $proxy_server '$upstream_http_location';
@@ -26,5 +26,5 @@ location @handle_proxy {
   proxy_set_header X-Forwarded-Proto https;
   proxy_intercept_errors on;
   recursive_error_pages on;
-  error_page 301 302 307 = @handle_proxy;
+  error_page 307 = @handle_proxy;
 }

--- a/etc/nginx-openhabcloud-lb.conf
+++ b/etc/nginx-openhabcloud-lb.conf
@@ -74,7 +74,7 @@ server {
 		proxy_set_header X-Forwarded-Proto https;
 		proxy_intercept_errors on;
 		recursive_error_pages on;
-		error_page 301 302 307 = @handle_proxy;
+		error_page 307 = @handle_proxy;
 		#if this server is down we need to try a new upstream
 		error_page 500 501 502 503 504 = @proxy_down;
 	}
@@ -162,7 +162,7 @@ server {
 	  proxy_set_header X-Forwarded-Proto https;
 		proxy_intercept_errors on;
 		recursive_error_pages on;
-	  error_page 301 302 307 = @handle_proxy;
+	  error_page 307 = @handle_proxy;
 	  #if this server is down we need to try a new upstream
 	  error_page 500 501 502 503 504 = @proxy_down;
 	}

--- a/routes/ifttt.js
+++ b/routes/ifttt.js
@@ -133,7 +133,7 @@ exports.v1actioncommand = [
             }
             // If OH lives on another server, redirect to that internally (nginx)
             if (openhab.serverAddress != system.getInternalAddress()){
-              return res.redirect(302, 'http://' + openhab.serverAddress + req.path);
+              return res.redirect(307, 'http://' + openhab.serverAddress + req.path);
             }
             app.sio.sockets.in(openhab.uuid).emit('command', {item: req.body.actionFields.item, command: req.body.actionFields.command});
             return res.json({data:[{id: "12345"}]});

--- a/routes/index.js
+++ b/routes/index.js
@@ -289,7 +289,7 @@ Routes.prototype.ensureStaff = function (req, res, next) {
 Routes.prototype.ensureServer = function(req, res, next) {
   if (req.openhab.serverAddress != system.getInternalAddress()){
     //redirect a request to correct cloud server
-    res.redirect(302, 'http://' + req.openhab.serverAddress + req.path);
+    res.redirect(307, 'http://' + req.openhab.serverAddress + req.path);
   } else {
     res.cookie('CloudServer',system.getInternalAddress(), { maxAge: 900000, httpOnly: true });
     return next();

--- a/routes/index.js
+++ b/routes/index.js
@@ -362,7 +362,6 @@ Routes.prototype.proxyRouteOpenhab = function (req, res) {
     // We need to remove and modify some headers here
     delete requestHeaders['cookie'];
     delete requestHeaders['cookie2'];
-    delete requestHeaders['authorization'];
     delete requestHeaders['x-real-ip'];
     delete requestHeaders['x-forwarded-for'];
     delete requestHeaders['x-forwarded-proto'];
@@ -376,6 +375,9 @@ Routes.prototype.proxyRouteOpenhab = function (req, res) {
         // TODO: this is too dirty :-(
         delete requestHeaders['host'];
         requestHeaders['host'] = 'home.' + system.getHost() + ':' + system.getPort();
+    } else {
+        // if full proxing , allow the auth header through to support oh3 authentication. 
+        delete requestHeaders['authorization'];
     }
 
     // Send a message with request to openhab agent module

--- a/routes/index.js
+++ b/routes/index.js
@@ -376,7 +376,8 @@ Routes.prototype.proxyRouteOpenhab = function (req, res) {
         delete requestHeaders['host'];
         requestHeaders['host'] = 'home.' + system.getHost() + ':' + system.getPort();
     } else {
-        // if full proxing , allow the auth header through to support oh3 authentication. 
+        // if not full proxing , dont't pass the auth header from our cloud service through
+        // will conflict with oh3 authentication  
         delete requestHeaders['authorization'];
     }
 

--- a/routes/index.js
+++ b/routes/index.js
@@ -362,6 +362,7 @@ Routes.prototype.proxyRouteOpenhab = function (req, res) {
     // We need to remove and modify some headers here
     delete requestHeaders['cookie'];
     delete requestHeaders['cookie2'];
+    delete requestHeaders['authorization'];
     delete requestHeaders['x-real-ip'];
     delete requestHeaders['x-forwarded-for'];
     delete requestHeaders['x-forwarded-proto'];
@@ -375,10 +376,6 @@ Routes.prototype.proxyRouteOpenhab = function (req, res) {
         // TODO: this is too dirty :-(
         delete requestHeaders['host'];
         requestHeaders['host'] = 'home.' + system.getHost() + ':' + system.getPort();
-    } else {
-        // if not full proxing , dont't pass the auth header from our cloud service through
-        // will conflict with oh3 authentication  
-        delete requestHeaders['authorization'];
     }
 
     // Send a message with request to openhab agent module

--- a/system/mongoconnect.js
+++ b/system/mongoconnect.js
@@ -55,7 +55,7 @@ MongoConnect.prototype.getMongoUri = function () {
 
     mongoUri += this.system.getDbHostsString();
 
-    return mongoUri + '/' + this.system.getDbName() + '?poolSize=100';
+    return mongoUri + '/' + this.system.getDbName() + '?poolSize=50';
 };
 
 module.exports = MongoConnect;


### PR DESCRIPTION
This changes the internal proxy redirect code to use 307 so as to not conflict with OH3 oauth redirection and sets the mongo pool to match what is in production today.

Signed-off-by: digitaldan <dan@digitaldan.com>