### PR TITLE
Remove OpenhabCloud's Authorization Header to OH3

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -370,7 +370,7 @@ Routes.prototype.proxyRouteOpenhab = function (req, res) {
     delete requestHeaders['x-forwarded-for'];
     delete requestHeaders['x-forwarded-proto'];
     delete requestHeaders['connection'];
-    requestHeaders['host'] = req.headers.host || system.getHost() + ':' + system.getPort();
+    requestHeaders['host'] = req.headers["x-forwarded-host"] || system.getHost() + ':' + system.getPort();
     requestHeaders['user-agent'] = 'openhab-cloud/0.0.1';
     // Strip off path prefix for remote vhosts hack
     var requestPath = req.path;

--- a/routes/index.js
+++ b/routes/index.js
@@ -377,6 +377,9 @@ Routes.prototype.proxyRouteOpenhab = function (req, res) {
     if (requestPath.indexOf('/remote/') === 0) {
         requestPath = requestPath.replace('/remote', '');
         // TODO: this is too dirty :-(
+        if(requestPath.indexOf('/remote/auth') !== 0){
+            delete requestHeaders['authorization'];
+        }
         delete requestHeaders['host'];
         requestHeaders['host'] = 'home.' + system.getHost() + ':' + system.getPort();
     }


### PR DESCRIPTION
The problem that i am facing is openhabcloud actually passes its credentials via authorization header to remote openhab instance, which username and passwords are different. 