### PR TITLE
resets buffer size to avoid upgrade issues,  previous default in engi…

### DIFF
--- a/app.js
+++ b/app.js
@@ -316,6 +316,7 @@ var server = app.listen(system.getNodeProcessPort(), config.system.listenIp, fun
 });
 
 var io = require('socket.io')(server, {
+    maxHttpBufferSize: 1e8, //100mb, this was a previous default in engine.io before the upgrade to 3.6.0 which sets it to 1mb.  May want to revisit.
     logger: logger
 });
 


### PR DESCRIPTION
…ne.io before the upgrade to 3.6.0 which sets it to 1mb.

Signed-off-by: Dan Cunningham <dan@digitaldan.com>