### PR TITLE
Auth change and logging

### DIFF
--- a/app.js
+++ b/app.js
@@ -393,7 +393,7 @@ io.use(function (socket, next) {
     handshakeData.openhabVersion = handshakeData.query['openhabversion'];
     handshakeData.clientVersion = handshakeData.query['clientVersion'];
     handshakeSecret = handshakeData.query['secret'];
-    ogger.info('openHAB-cloud: Authorizing incoming openHAB connection for ' + handshakeData.uuid );
+    logger.info('openHAB-cloud: Authorizing incoming openHAB connection for ' + handshakeData.uuid );
     if (!handshakeData.uuid) {
         handshakeData.uuid = handshakeData.headers['uuid'];
         handshakeSecret = handshakeData.headers['secret'];

--- a/app.js
+++ b/app.js
@@ -389,11 +389,11 @@ function sendIosNotifications(iosDeviceTokens, notification) {
 
 io.use(function (socket, next) {
     var handshakeData = socket.handshake;
-    logger.info('openHAB-cloud: Authorizing incoming openHAB connection');
     handshakeData.uuid = handshakeData.query['uuid'];
     handshakeData.openhabVersion = handshakeData.query['openhabversion'];
     handshakeData.clientVersion = handshakeData.query['clientVersion'];
     handshakeSecret = handshakeData.query['secret'];
+    ogger.info('openHAB-cloud: Authorizing incoming openHAB connection for ' + handshakeData.uuid );
     if (!handshakeData.uuid) {
         handshakeData.uuid = handshakeData.headers['uuid'];
         handshakeSecret = handshakeData.headers['secret'];
@@ -457,7 +457,7 @@ io.sockets.on('connection', function (socket) {
                 socket.disconnect();
                 return;
             }
-            logger.info('openHAB-cloud: connect success uuid ' + openhab.uuid + ' prevous address ' + lastServerAddress + " my address " + internalAddress);      
+            logger.info('openHAB-cloud: connect success uuid ' + openhab.uuid + ' connectionId ' + socket.connectionId  + ' prevous address ' + lastServerAddress + " my address " + internalAddress);      
 
             socket.openhabId = openhab.id;
             
@@ -540,7 +540,7 @@ io.sockets.on('connection', function (socket) {
                     request.send(data.responseStatusCode, new Buffer(data.body, 'base64'));
                 }
             } else {
-                logger.warn('openHAB-cloud: ' + self.handshake.uuid + ' tried to respond to request which it doesn\'t own');
+                logger.warn('openHAB-cloud: response ' + self.handshake.uuid + ' tried to respond to request which it doesn\'t own' + request.openhab.uuid);
             }
         } else {
             self.emit('cancel', {
@@ -557,7 +557,7 @@ io.sockets.on('connection', function (socket) {
             if (self.handshake.uuid === request.openhab.uuid && !request.headersSent) {
                 request.writeHead(data.responseStatusCode, data.responseStatusText, data.headers);
             } else {
-                logger.warn('openHAB-cloud: ' + self.handshake.uuid + ' tried to respond to request which it doesn\'t own');
+                logger.warn('openHAB-cloud: responseHeader ' + self.handshake.uuid + ' tried to respond to request which it doesn\'t own ' + request.openhab.uuid + " or headers have already been sent");
             }
         } else {
             self.emit('cancel', {
@@ -575,7 +575,7 @@ io.sockets.on('connection', function (socket) {
             if (self.handshake.uuid === request.openhab.uuid) {
                 request.write(new Buffer(data.body, 'base64'));
             } else {
-                logger.warn('openHAB-cloud: ' + self.handshake.uuid + ' tried to respond to request which it doesn\'t own');
+                logger.warn('openHAB-cloud: responseContent ' + self.handshake.uuid + ' tried to respond to request which it doesn\'t own' + request.openhab.uuid);
             }
         } else {
             self.emit('cancel', {
@@ -593,7 +593,7 @@ io.sockets.on('connection', function (socket) {
             if (self.handshake.uuid === request.openhab.uuid) {
                 request.write(data.body);
             } else {
-                logger.warn('openHAB-cloud: ' + self.handshake.uuid + ' tried to respond to request which it doesn\'t own');
+                logger.warn('openHAB-cloud: responseContentBinary ' + self.handshake.uuid + ' tried to respond to request which it doesn\'t own ' + request.openhab.uuid);
             }
         } else {
             self.emit('cancel', {
@@ -610,7 +610,7 @@ io.sockets.on('connection', function (socket) {
             if (self.handshake.uuid === request.openhab.uuid) {
                 request.end();
             } else {
-                logger.warn('openHAB-cloud: ' + self.handshake.uuid + ' tried to respond to request which it doesn\'t own');
+                logger.warn('openHAB-cloud: responseFinished ' + self.handshake.uuid + ' tried to respond to request which it doesn\'t own' + request.openhab.uuid);
             }
         }
     });
@@ -623,7 +623,7 @@ io.sockets.on('connection', function (socket) {
             if (self.handshake.uuid === request.openhab.uuid) {
                 request.send(500, data.responseStatusText);
             } else {
-                logger.warn('openHAB-cloud: ' + self.handshake.uuid + ' tried to respond to request which it doesn\'t own');
+                logger.warn('openHAB-cloud: responseError ' + self.handshake.uuid + ' tried to respond to request which it doesn\'t own' + request.openhab.uuid);
             }
         }
     });

--- a/app.js
+++ b/app.js
@@ -407,16 +407,20 @@ io.use(function (socket, next) {
         handshakeData.clientVersion = 'unknown';
     }
     Openhab.findOne({
-        uuid: handshakeData.uuid,
-        secret: handshakeSecret
+        uuid: handshakeData.uuid
     }, function (error, openhab) {
         if (error) {
             logger.error('openHAB-cloud: openHAB lookup error: ' + error);
             next(error);
         } else {
             if (openhab) {
-                socket.openhab = openhab; // will use this reference in 'connect' to save on mongo calls
-                next();
+                if(openhab.secret === handshakeSecret) {
+                    socket.openhab = openhab; // will use this reference in 'connect' to save on mongo calls
+                    next();
+                } else {
+                    logger.info('openHAB-cloud: openHAB ' + handshakeData.uuid + ' secret does not match');
+                    next(new Error('not authorized'));
+                }
             } else {
                 logger.info('openHAB-cloud: openHAB ' + handshakeData.uuid + ' not found');
                 next(new Error('not authorized'));


### PR DESCRIPTION
Mongo can not index on the auth secret due to length sizes, so lookup just the id and check that they match.  Also adds additional logging. 