### PR TITLE
fixing req.logout() because of the 0.6.0 update of passport

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -73,8 +73,9 @@ Routes.prototype.setupGeneralRoutes = function (app) {
 };
 
 Routes.prototype.setupLoginLogoutRoutes = function (app) {
-    app.get('/logout', function (req, res) {
-        req.logout();
+    app.get('/logout', function (req, res, next) {
+        req.logout(function(err) {
+        if (err) { return next(err); }
         res.redirect('/');
     });
 


### PR DESCRIPTION
req.logout() doesn't work since passport updated to 0.6.0 and req.logout() is now asynchronous whereas previously was synchronous. 

Signed-off-by: Javaded <j.effatdoost@gmail.com>