### PR TITLE
lock timeout tweak

### DIFF
--- a/system/index.js
+++ b/system/index.js
@@ -187,7 +187,7 @@ System.prototype.getConnectionLockTimeSeconds = function() {
     try {
         return this.getConfig(['system', 'connectionLockTimeSeconds']);
     } catch (e) {
-        return 70;
+        return 60;
     }
 };
 


### PR DESCRIPTION
socket.io by default uses a 25 second ping and 20 second timeout, so 45 seconds. 60 seconds gives us that plus a little buffer before redis expires a key.  This should only be used if something goes wrong on the server and the socket.io keepalive functionality fails, as a socket.io timeout will clear the redis key before the expire happens. 

Signed-off-by: Dan Cunningham <dan@digitaldan.com>