### PR TITLE
Fix login original url redirect

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -95,7 +95,7 @@ Routes.prototype.setupLoginLogoutRoutes = function (app) {
     });
 
     app.post('/login', account_routes.loginpostvalidate,
-        //use express-form sanitized data for passport  
+        //use express-form sanitized data for passport
         function (req, res, next) {
             req.body.username = req.form.username;
             req.body.password = req.form.password;
@@ -104,7 +104,8 @@ Routes.prototype.setupLoginLogoutRoutes = function (app) {
         passport.authenticate('local', {
             successReturnToOrRedirect: '/',
             failureRedirect: '/login',
-            failureFlash: true
+            failureFlash: true,
+            keepSessionInfo: true
         }));
 };
 


### PR DESCRIPTION
`passportjs` v0.6 introduced a breaking change that [no longer preserve session info](https://medium.com/passportjs/fixing-session-fixation-b2b68619c51d) by default for security reasons, preventing the session `returnTo` property from persisting after successfully logging in.

Property `keepSessionInfo` was added in order to give the option to go back to how it used to behave.