### PR TITLE
Proxy WebSocket connections

### DIFF
--- a/etc/nginx-openhabcloud-lb.conf
+++ b/etc/nginx-openhabcloud-lb.conf
@@ -142,6 +142,35 @@ server {
 	#proxy redirects
 	include nginx-openhabcloud-lb-redirects.conf;
 
+	#Proxied WebSocket Connections (from clients) # same as next block but proxy upgrade and connection headers
+	location ~ ^/ws {
+	  set $upstream_server proxyapp;
+	  #if we have a cookie, try using this server
+	  #also, ifIsEvil https://www.nginx.com/resources/wiki/start/topics/depth/ifisevil/
+	  #for why we use this as little as possible
+	  if ($http_cookie ~ "CloudServer=(\S+)\%3A(\d+).*") {
+	    set $upstream_host $1;
+	    set $upstream_port $2;
+	    set $upstream_server "${upstream_host}:${upstream_port}";
+	  }
+	  proxy_pass http://$upstream_server;
+	  proxy_redirect off;
+	  proxy_http_version 1.1;
+	  proxy_set_header Host $host;
+	  proxy_set_header X-Real-IP $remote_addr ;
+	  proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for ;
+	  proxy_set_header X-Forwarded-Proto https;
+	  // allow connection upgrade
+	  proxy_set_header Upgrade $http_upgrade;
+	  proxy_set_header Connection $connection_upgrade;
+
+		proxy_intercept_errors on;
+		recursive_error_pages on;
+	  error_page 307 = @handle_proxy;
+	  #if this server is down we need to try a new upstream
+	  error_page 500 501 502 503 504 = @proxy_down;
+	}
+
 	#Proxied Connections (from clients)
 	location ~ ^/(rest|images|static|rrdchart.png|chart|openhab.app|WebApp|CMD|cometVisu|proxy|greent|jquery|classicui|ui|basicui|paperui|doc|start|icon|habmin|remote|habpanel|ifttt/v1/actions/command){
 	  set $upstream_server proxyapp;

--- a/etc/nginx_openhabcloud-production.conf
+++ b/etc/nginx_openhabcloud-production.conf
@@ -86,7 +86,7 @@ location /downloads {
     alias /opt/openhabcloud/public/downloads;
     }
 
-location ~ ^/(socket.io|rest|images|static|rrdchart.png|chart|openhab.app|WebApp|CMD|cometVisu|proxy|greent|jquery|classicui|ui|basicui|doc|start|icon|habmin|remote|habpanel|ifttt/v1/actions/command){
+location ~ ^/(socket.io|rest|ws|images|static|rrdchart.png|chart|openhab.app|WebApp|CMD|cometVisu|proxy|greent|jquery|classicui|ui|basicui|doc|start|icon|habmin|remote|habpanel|ifttt/v1/actions/command){
     proxy_pass http://socketapp;
     proxy_redirect off;
     proxy_http_version 1.1;

--- a/routes/androidRegistrationService.js
+++ b/routes/androidRegistrationService.js
@@ -10,7 +10,7 @@ var logger = require('../logger');
  */
 module.exports = function (req, res) {
     if (!req.query.hasOwnProperty('regId') || !req.query.hasOwnProperty('deviceId')) {
-        res.send(404, 'Parameters missing');
+        res.status(404).send('Parameters missing');
         return;
     }
     var regId = req.query['regId'];
@@ -25,7 +25,7 @@ module.exports = function (req, res) {
     }, function (error, userDevice) {
         if (error) {
             logger.warn('Error looking up device: ' + error);
-            res.send(500, 'Internal server error');
+            res.status(500).send('Internal server error');
             return;
         }
 
@@ -39,7 +39,7 @@ module.exports = function (req, res) {
                     logger.error('Error saving user device: ' + error);
                 }
             });
-            res.send(200, 'Updated');
+            res.status(200).send('Updated');
         } else {
             // If not found, try to find device by registration id. Sometimes android devices change their
             // ids dynamically, while google play services continue to return the same registration id
@@ -68,7 +68,7 @@ module.exports = function (req, res) {
             function (error, userDevice) {
                 if (error) {
                     logger.warn('Error looking up device: ' + error);
-                    res.send(500, 'Internal server error');
+                    res.status(500).send('Internal server error');
                     return;
                 }
                 if (userDevice) {
@@ -80,7 +80,7 @@ module.exports = function (req, res) {
                             logger.error('Error saving user device: ' + error);
                         }
                     });
-                    res.send(200, 'Updated');
+                    res.status(200).send('Updated');
                 } else {
                     // If not found, finally register a new one
                     userDevice = new UserDevice({
@@ -97,7 +97,7 @@ module.exports = function (req, res) {
                             logger.error('Error saving user device: ' + error);
                         }
                     });
-                    res.send(200, 'Added');
+                    res.status(200).send('Added');
                 }
             });
     };

--- a/routes/appleRegistrationService.js
+++ b/routes/appleRegistrationService.js
@@ -10,7 +10,7 @@ var logger = require('../logger');
  */
 module.exports = function (req, res) {
     if (!req.query.hasOwnProperty('regId') || !req.query.hasOwnProperty('deviceId')) {
-        res.send(404, 'Parameters missing');
+        res.status(404).send('Parameters missing');
         return;
     }
     var regId = req.query['regId'];
@@ -24,7 +24,7 @@ module.exports = function (req, res) {
     }, function (error, userDevice) {
         if (error) {
             logger.warn('Error looking up device: ' + error);
-            res.send(500, 'Internal server error');
+            res.status(500).send('Internal server error');
             return;
         }
         if (userDevice) {
@@ -37,7 +37,7 @@ module.exports = function (req, res) {
                     logger.error('Error saving user device: ' + error);
                 }
             });
-            res.send(200, 'Updated');
+            res.status(200).send('Updated');
         } else {
             // If not found, add new device registration
             logger.info('Registering new iOS device for user ' + req.user.username);
@@ -55,7 +55,7 @@ module.exports = function (req, res) {
                     logger.error('Error saving user device: ' + error);
                 }
             });
-            res.send(200, 'Added');
+            res.status(200).send('Added');
         }
     });
 };

--- a/routes/setTimezone.js
+++ b/routes/setTimezone.js
@@ -1,4 +1,4 @@
 module.exports = function (req, res) {
     req.session.timezone = req.query['tz'];
-    res.send(200, 'Timezone set');
+    res.status(200).send('Timezone set');
 };

--- a/socket-io.js
+++ b/socket-io.js
@@ -210,7 +210,42 @@ function SocketIO(server, system) {
             if (requestTracker.has(requestId)) {
                 request = requestTracker.get(requestId);
                 if (self.handshake.uuid === request.openhab.uuid && !request.headersSent) {
-                    request.writeHead(data.responseStatusCode, data.responseStatusText, data.headers);
+                    if (data.responseStatusCode != '101')  {
+                        request.writeHead(data.responseStatusCode, data.responseStatusText, data.headers);
+                    } else {
+                        // request was upgraded on the remote
+                        logger.debug('Upgrading request ' + requestId);
+                        const websocket = request.socket;
+                        websocket.setTimeout(0);
+                        websocket.setNoDelay();
+                        // setup socket event listeners
+                        websocket.on('data', (data) => {
+                            self.emit('websocket', requestId, new Uint8Array(data).buffer);
+                        });
+                        websocket.on('error', (error) => {
+                            logger.warn("Socket error for request " + requestId + ": " + error.message);
+                        });
+                        websocket.on('close', () => {
+                            logger.debug("Socket closed for request " + requestId);
+                            if(requestTracker.has(requestId)) {
+                                requestTracker.remove(requestId);
+                                self.emit('cancel', { id: requestId });
+                            }
+                        });
+                        websocket.on('end', () => {
+                            logger.debug("Socket ended for request " + requestId);
+                            if(requestTracker.has(requestId)) {
+                                requestTracker.remove(requestId);
+                                self.emit('cancel', { id: requestId });
+                            }
+                        });
+                        // write upgrade to client
+                        const statusLine = `HTTP/1.1 ${data.responseStatusCode} ${data.responseStatusText || 'Switching Protocols'}\r\n`
+                        const headerList = Object.entries(data.headers).map(entry => `${entry[0]}: ${entry[1]}`);
+                        const header = `${statusLine}${headerList.concat('\r\n').join('\r\n')}`;
+                        // note response writeHead method can not be used because it will close the socket
+                        websocket.write(header);
+                    }
                 } else {
                     logger.warn('responseHeader %s tried to respond to request which it doesn\'t own %s or headers have already been sent', self.handshake.uuid, request.openhab.uuid);
                 }
@@ -257,9 +292,21 @@ function SocketIO(server, system) {
             if (requestTracker.has(requestId)) {
                 request = requestTracker.get(requestId);
                 if (self.handshake.uuid === request.openhab.uuid) {
-                    request.send(500, data.responseStatusText);
+                    request.status(500).send(data.responseStatusText);
                 } else {
                     logger.warn('responseError %s tried to respond to request which it doesn\'t own %s', self.handshake.uuid, request.openhab.uuid);
+                }
+            }
+        });
+        socket.on('websocket', function (requestId, data) {
+            var self = this;
+            if (requestTracker.has(requestId)) {
+                var request = requestTracker.get(requestId);
+                if (self.handshake.uuid === request.openhab.uuid) {
+                    // write data to upgraded request socket handling backpressure
+                    writeToSocket(request.socket, data);
+                } else {
+                    logger.warn('responseError %s tried to send websocket data to request which it doesn\'t own %s', self.handshake.uuid, request.openhab.uuid);
                 }
             }
         });
@@ -377,6 +424,43 @@ function SocketIO(server, system) {
                 logger.error('Error saving connect event: %s', error);
             }
         });
+    }
+    /**
+     * Symbol used to indicate whetter the socket can be written
+     */
+    const WritingState = Symbol('writing');
+    /**
+     * Symbol used hold a queue of pending writes
+     */
+    const PendingWrites = Symbol('pending');
+    /**
+     * Write to socket handling backpressure
+     */
+    function writeToSocket(stream, data) {
+        const pending = stream[PendingWrites] = (stream[PendingWrites] || []);
+        if (stream[WritingState]) {
+            pending.push(data);
+        } else {
+            const cb = () => {
+                if (pending.length) {
+                    _writeToSocket(stream, pending.shift(), cb);
+                } else {
+                    stream[WritingState] = false;
+                }
+            };
+            stream[WritingState] = true;
+            _writeToSocket(stream, data, cb)
+        }
+    }
+    /**
+     * Internal function called from writeToSocket 
+     */
+    function _writeToSocket(stream, data, cb) {
+        if (!stream.write(data)) {
+            stream.once('drain', cb);
+        } else {
+            cb();
+        }
     }
 
     /**


### PR DESCRIPTION
Hello, these is a proposed PR to allow proxy WebSocket connections to the OpenHAB instances exposed under path /ws/.

With the PR, the code catches the upgraded response headers and setup the required listeners on the request Socket in order to transfer the incoming data through the Socket.IO connection to the destination server using the "websocket" event. Also handles the "websocket" events from the remote server and write the received data to the socket.

I have also changed the responses like `res.send(200, '...');` to be `res.status(200).send('...');` because I saw deprecation warnings when running the project using docker-compose.

These PR needs changes in the Cloud Connector add-on.