### PR TITLE
add a health endpoint

### DIFF
--- a/config-development.json
+++ b/config-development.json
@@ -9,7 +9,10 @@
             "maxFiles" : "7d",
             "level" : "debug",
             "morganOption" : "dev"
-          }
+          },
+        "healthEndpoint" : {
+          "enabled" : true
+        }
     },
     "express":{
       "key" : "some express key"

--- a/config-production.json
+++ b/config-production.json
@@ -11,7 +11,10 @@
         "morganOption" : null
       },
       "subDomainCookies": false,
-      "muteNotifications": false
+      "muteNotifications": false,
+      "healthEndpoint" : {
+        "enabled" : false
+      }
     },
     "express":{
       "key" : "some express key"

--- a/deployment/docker-compose/config.json.template
+++ b/deployment/docker-compose/config.json.template
@@ -6,7 +6,10 @@
       "logger" : {
         "type": "console"
       },
-      "subDomainCookies": false
+      "subDomainCookies": false,
+      "healthEndpoint" : {
+          "enabled" : false
+        }
     },
     "express":{
       "key" : "${EXPRESS_KEY}"

--- a/routes/health.js
+++ b/routes/health.js
@@ -1,4 +1,4 @@
-var app = require('../app');
+var system = require('../system');
 
 var mongoose = require('mongoose');
 
@@ -6,44 +6,49 @@ const Errors = {
     DBERROR: 'DBERROR'
 }
 
-exports.gethealth = function(req, res) {
-    const mongoose_state = mongoose.connection.readyState
-    var errors = collectErrors();
-    if (errors.length == 0) {
-        res.status(200).json({
-            status: "OK",
-            mongoose: mongoose_state
-        });
+exports.gethealth = function (req, res) {
+    const isHealthEndpointEnabled = system.isHealthEndpointEnabled();
+    if (!isHealthEndpointEnabled) {
+        return res.status(404).send("not found");
     } else {
-        return res.status(500).json({
-            status: "Not OK",
-            mongoose: mongoose_state,
-            errors: errors
-        });
-    }
+        const mongoose_state = mongoose.connection.readyState
+        var errors = collectErrors();
+        if (errors.length == 0) {
+            return res.status(200).json({
+                status: "OK",
+                mongoose: mongoose_state
+            });
+        } else {
+            return res.status(500).json({
+                status: "Not OK",
+                mongoose: mongoose_state,
+                errors: errors
+            });
+        }
 
-    function collectErrors() {
-        var errors = [];
-        switch (mongoose_state) {
-            case 0:
-                errors.push({
-                    error: Errors.DBERROR,
-                    message: "mongodb disconnected"
-                });
-                break;
-            case 2:
-                errors.push({
-                    error: Errors.DBERROR,
-                    message: "mongodb connecting"
-                });
-                break;
-            case 3:
-                errors.push({
-                    error: Errors.DBERROR,
-                    message: "mongodb disconnecting"
-                });
-                break;
-        };
-        return errors;
+        function collectErrors() {
+            var errors = [];
+            switch (mongoose_state) {
+                case 0:
+                    errors.push({
+                        error: Errors.DBERROR,
+                        message: "mongodb disconnected"
+                    });
+                    break;
+                case 2:
+                    errors.push({
+                        error: Errors.DBERROR,
+                        message: "mongodb connecting"
+                    });
+                    break;
+                case 3:
+                    errors.push({
+                        error: Errors.DBERROR,
+                        message: "mongodb disconnecting"
+                    });
+                    break;
+            };
+            return errors;
+        }
     }
 };

--- a/routes/health.js
+++ b/routes/health.js
@@ -1,0 +1,49 @@
+var app = require('../app');
+
+var mongoose = require('mongoose');
+
+const Errors = {
+    DBERROR: 'DBERROR'
+}
+
+exports.gethealth = function(req, res) {
+    const mongoose_state = mongoose.connection.readyState
+    var errors = collectErrors();
+    if (errors.length == 0) {
+        res.status(200).json({
+            status: "OK",
+            mongoose: mongoose_state
+        });
+    } else {
+        return res.status(500).json({
+            status: "Not OK",
+            mongoose: mongoose_state,
+            errors: errors
+        });
+    }
+
+    function collectErrors() {
+        var errors = [];
+        switch (mongoose_state) {
+            case 0:
+                errors.push({
+                    error: Errors.DBERROR,
+                    message: "mongodb disconnected"
+                });
+                break;
+            case 2:
+                errors.push({
+                    error: Errors.DBERROR,
+                    message: "mongodb connecting"
+                });
+                break;
+            case 3:
+                errors.push({
+                    error: Errors.DBERROR,
+                    message: "mongodb disconnecting"
+                });
+                break;
+        };
+        return errors;
+    }
+};

--- a/routes/index.js
+++ b/routes/index.js
@@ -1,5 +1,6 @@
 var system = require('../system'),
     homepage = require('./homepage'),
+    health_routes = require('./health'),
     passport = require('passport'),
     account_routes = require('./account'),
     devices_routes = require('./devices'),
@@ -56,6 +57,9 @@ Routes.prototype.setupRoutes = function (app) {
 Routes.prototype.setupGeneralRoutes = function (app) {
     // General homepage
     app.get('/', this.setOpenhab, homepage.index);
+
+    // Health page
+    app.get('/health', this.setOpenhab, health_routes.gethealth);
 
     // Events
     app.get('/events', this.ensureAuthenticated, this.setOpenhab, events_routes.eventsget);

--- a/system/index.js
+++ b/system/index.js
@@ -443,4 +443,16 @@ System.prototype.getLoggerType = function() {
     }
 };
 
+/**
+ * Returns true, if health endpoint is enabled.
+ * @return {boolean}
+ */
+System.prototype.isHealthEndpointEnabled = function() {
+    try {
+        return this.getConfig(['system', 'healthEndpoint', 'enabled']);
+    } catch(e) {
+        return false;
+    }
+};
+
 module.exports = new System();


### PR DESCRIPTION
I use openhab cloud in a kubernetes environment. When the mongodb connection gets lost, it doesn't recover alone. 

Kubernetes doesn't see that the state isn't healthy by just probing the home page. So I created a health endpoint that returns HTTP status 200 in case every is ok, else it returns HTTP status 500.