### PR TITLE
[WIP] auth2 proxy

### DIFF
--- a/app.js
+++ b/app.js
@@ -154,7 +154,7 @@ app.use(function (req, res, next) {
 app.use(function (req, res, next) {
     var csrf = csurf();
     // Check if url needs csrf, remote connections and REST connections are excluded from CSRF
-    if (!req.path.match('/api/*') && !req.path.match('/rest*') && !req.path.match('/oauth2/token') && !req.path.match('/ifttt/*') && !req.path.match('/remote/*'))
+    if (!req.path.match('/api/*') && !req.path.match('/rest*') && !req.path.match('/oauth2/token') && !req.path.match('/oauth2proxy/token') && !req.path.match('/ifttt/*') && !req.path.match('/remote/*'))
         csrf(req, res, next);
     else
         next();

--- a/models/oauth2relay.js
+++ b/models/oauth2relay.js
@@ -1,0 +1,21 @@
+var mongoose = require('mongoose'),
+    Schema = mongoose.Schema;
+var ObjectId = mongoose.SchemaTypes.ObjectId;
+
+var OAuth2RelaySchema = new Schema({
+    name: String,                               // Client name
+    description: String,
+    homeUrl: String,
+    icon: String,
+    clientId: String,                           // Client oauth2 id
+    clientSecret: String,                       // Client oauth2 secret
+    targetAuthorizeUrl: String,
+    targetTokenUrl: String,
+    active: { type: Boolean, default: true},    // If this client is active?
+    created: { type: Date, default: Date.now }, // When client was created
+    last_change: Date                           // Date/time of last client change
+});
+
+OAuth2RelaySchema.index({clientId:1}, { unique: true }); // to find client by client id
+
+module.exports = mongoose.model('OAuth2Relay', OAuth2RelaySchema);

--- a/models/oauth2relay.js
+++ b/models/oauth2relay.js
@@ -10,6 +10,7 @@ var OAuth2RelaySchema = new Schema({
     clientId: String,                           // Client oauth2 id
     clientSecret: String,                       // Client oauth2 secret
     targetAuthorizeUrl: String,
+    targetHost: String,
     targetTokenUrl: String,
     active: { type: Boolean, default: true},    // If this client is active?
     created: { type: Date, default: Date.now }, // When client was created

--- a/routes/index.js
+++ b/routes/index.js
@@ -13,6 +13,7 @@ const system = require('../system'),
     staff_routes = require('./staff'),
     api_routes = require('./api'),
     oauth2 = require('./oauth2'),
+    oauth2proxy = require('./oauth2proxy'),
     setSessionTimezone = require('./setTimezone'),
     fcmRegistrationService = require('./fcmRegistrationService'),
     appleRegistrationService = require('./appleRegistrationService'),
@@ -47,6 +48,7 @@ Routes.prototype.setupRoutes = function (app) {
     this.setupInvitationRoutes(app);
     this.setupUserManagementRoutes(app);
     this.setupOAuthRoutes(app);
+    this.setupOAuthProxyRoutes(app);
     this.setupIFTTTRoutes(app);
     this.setupTimezoneRoutes(app);
     this.setupStaffRoutes(app);
@@ -164,6 +166,12 @@ Routes.prototype.setupOAuthRoutes = function (app) {
     app.get('/oauth2/authorize', this.ensureAuthenticated, oauth2.authorization);
     app.post('/oauth2/authorize/decision', this.ensureAuthenticated, oauth2.decision);
     app.post('/oauth2/token', oauth2.token);
+};
+
+
+Routes.prototype.setupOAuthProxyRoutes = function (app) {
+    app.get('/oauth2proxy/authorize', this.ensureAuthenticated, oauth2proxy.authorization);
+    app.post('/oauth2proxy/token', oauth2proxy.token);
 };
 
 Routes.prototype.setupStaffRoutes = function (app) {

--- a/routes/oauth2proxy.js
+++ b/routes/oauth2proxy.js
@@ -1,0 +1,137 @@
+var oauth2orize = require('oauth2orize'),
+    passport = require('passport'),
+    http = require('node:http'),
+    net = require('node:net'),
+    OAuth2Client = require('../models/oauth2client'),
+    OAuth2Code = require('../models/oauth2code'),
+    OAuth2Token = require('../models/oauth2token'),
+    OAuth2Scope = require('../models/oauth2scope'),
+    OAuth2Relay = require('../models/oauth2relay'),
+    logger = require('../logger.js'),
+    server = oauth2orize.createServer();
+ 
+// An application must supply serialization functions, which determine how the
+// client object is serialized into the session.  Typically this will be a
+// simple matter of serializing the client's ID, and deserializing by finding
+// the client by ID from the database.
+
+server.serializeClient(function (client, done) {
+    return done(null, client._id);
+});
+
+server.deserializeClient(function (id, done) { 
+    OAuth2Client.findOne({
+        _id: id
+    }, function (error, client) {
+        if (error) {
+            logger.error('deserializeClient: ' + error);
+            return done(error);
+        }
+        return done(null, client);
+    });
+});
+
+// Exchange authorization codes for access tokens.  The callback accepts the
+// `client`, which is exchanging `code` and any `redirectURI` from the
+// authorization request for verification.  If these values are validated, the
+// application issues an access token on behalf of the user who authorized the
+// code.
+
+
+exports.authorization = 
+    function (req, res) {
+        var errormessages,
+            infomessages,
+            relay;
+
+        errormessages = req.flash('error');
+        infomessages = req.flash('info');
+        relay = "Enedis";
+        logger.info('server.authorization oauth2 request for scope: ' + relay);
+        
+        OAuth2Relay.findOne({
+            name: relay
+        }, function (error, relay) {
+            if (error) {
+                req.flash('error', 'There was an error while processing your request');
+                res.redirect('/');
+            } else if (!relay) {
+                req.flash('info', 'The application requested access to unknown scope');
+                res.redirect('/');
+            } else {
+                var redirectUri = relay.targetAuthorizeUrl;
+
+                redirectUri = redirectUri + "?duration=P36M";
+                redirectUri = redirectUri + "&response_type=code";
+                redirectUri = redirectUri + "&client_id=" + relay.clientId;
+                redirectUri = redirectUri + "&state=" + "linky";
+                redirectUri = redirectUri + "&scope=" + "am_application_scope+default";
+                
+                logger.debug('redirectUri:' + redirectUri);
+                res.redirect(redirectUri);
+            }
+        });
+        
+    };
+
+
+
+exports.token = 
+    function (req, res) {
+        var errormessages,
+        infomessages,
+        relay;
+
+        errormessages = req.flash('error');
+        infomessages = req.flash('info');
+        
+        relay = "Enedis";
+
+        OAuth2Relay.findOne({
+            name: relay
+        }, function (error, relay) {
+            if (error) {
+                req.flash('error', 'There was an error while processing your request');
+                res.redirect('/');
+            } else if (!relay) {
+                req.flash('info', 'The application requested access to unknown scope');
+                res.redirect('/');
+            } else {
+                var https = require('https');
+                const options = {
+                host: 'ext.prod.api.enedis.fr',
+                port: 443,
+                path: '/oauth2/v3/token',
+                method: 'POST',
+                headers: {
+                    'Accept': 'application/json',
+                    'Accept-Encoding': '*',
+                    'Content-Type': 'application/x-www-form-urlencoded'
+                }
+                };
+
+                // Make a request
+                var req2 = https.request(options, function(res2) {
+                    console.log('STATUS: ' + res2.statusCode);
+                    console.log('HEADERS: ' + JSON.stringify(res2.headers));
+                    res2.setEncoding('utf8');
+                    res2.on('data', function (chunk) {
+                    console.log('BODY: ' + chunk);
+                    res.status(200).end(chunk);
+                    });
+                });
+                
+                req2.on('error', function(e) {
+                    console.log('problem with request: ' + e.message);
+                });
+                
+                // write data to request body
+                var clientId = relay.clientId;
+                var clientSecret = relay.clientSecret;
+                req2.write('client_id=' + clientId + '&client_secret=' + clientSecret + '&grant_type=client_credentials');
+                req2.end();
+            }
+        });
+    };
+
+

--- a/routes/oauth2proxy.js
+++ b/routes/oauth2proxy.js
@@ -9,7 +9,9 @@ var oauth2orize = require('oauth2orize'),
     OAuth2Relay = require('../models/oauth2relay'),
     logger = require('../logger.js'),
     server = oauth2orize.createServer();
+
  
+    
 // An application must supply serialization functions, which determine how the
 // client object is serialized into the session.  Typically this will be a
 // simple matter of serializing the client's ID, and deserializing by finding
@@ -24,12 +26,39 @@ server.deserializeClient(function (id, done) {
         _id: id
     }, function (error, client) {
         if (error) {
-            logger.error('deserializeClient: ' + error);
             return done(error);
         }
         return done(null, client);
     });
 });
+
+// Grant authorization codes.  The callback takes the `client` requesting
+// authorization, the `redirectURI` (which is used as a verifier in the
+// subsequent exchange), the authenticated `user` granting access, and
+// their response, which contains approved scope, duration, etc. as parsed by
+// the application.  The application issues a code, which is bound to these
+// values, and will be exchanged for an access token.
+
+server.grant(oauth2orize.grant.code(function (client, redirectURI, user, ares, done) {
+    console.log('==================== server.grant called');
+    console.log('client: ' + client);  
+    var code = uid(16),
+        newOAuthCode = new OAuth2Code({
+        user: user._id,
+        oAuthClient: client._id,
+        code: code,
+        redirectURI: redirectURI,
+        scope: ares.scope
+    });
+    newOAuthCode.save(function (error) {
+        if (error) {
+            logger.error('server.grant: ' + error);
+            return done(error);
+        }
+        done(null, code);
+    });
+}));
+
 
 // Exchange authorization codes for access tokens.  The callback accepts the
 // `client`, which is exchanging `code` and any `redirectURI` from the
@@ -37,101 +66,153 @@ server.deserializeClient(function (id, done) {
 // application issues an access token on behalf of the user who authorized the
 // code.
 
-
-exports.authorization = 
-    function (req, res) {
-        var errormessages,
-            infomessages,
-            relay;
-
-        errormessages = req.flash('error');
-        infomessages = req.flash('info');
-        relay = "Enedis";
-        logger.info('server.authorization oauth2 request for scope: ' + relay);
-        
-        OAuth2Relay.findOne({
-            name: relay
-        }, function (error, relay) {
-            if (error) {
-                req.flash('error', 'There was an error while processing your request');
-                res.redirect('/');
-            } else if (!relay) {
-                req.flash('info', 'The application requested access to unknown scope');
-                res.redirect('/');
-            } else {
-                var redirectUri = relay.targetAuthorizeUrl;
-
-                redirectUri = redirectUri + "?duration=P36M";
-                redirectUri = redirectUri + "&response_type=code";
-                redirectUri = redirectUri + "&client_id=" + relay.clientId;
-                redirectUri = redirectUri + "&state=" + "linky";
-                redirectUri = redirectUri + "&scope=" + "am_application_scope+default";
-                
-                logger.debug('redirectUri:' + redirectUri);
-                res.redirect(redirectUri);
-            }
-        });
-        
-    };
+server.exchange(oauth2orize.exchange.clientCredentials(function(client, scope, done) {
+    console.log('clientId: ' + client);
+    console.log('clientId: ' + client.clientId);
+    console.log('clientSecret: ' + client.clientSecret);
+    console.log('scope: ' + scope);
 
 
+    var token = "";
+    var expiresIn = 1800;
+    var expirationDate = new Date(new Date().getTime() + (expiresIn * 1000))
+    var scope = "";
+    var tokenType = "";
 
-exports.token = 
-    function (req, res) {
-        var errormessages,
-        infomessages,
-        relay;
 
-        errormessages = req.flash('error');
-        infomessages = req.flash('info');
-        
-        relay = "Enedis";
+    OAuth2Relay.findOne({
+        name: client.name
+    }, function (error, relay) {
+        if (error) {
+            return done(error);
+        } else if (!relay) {
+            return done("can't find relay");
+        } else {
+            console.log('relay:' + relay);
 
-        OAuth2Relay.findOne({
-            name: relay
-        }, function (error, relay) {
-            if (error) {
-                req.flash('error', 'There was an error while processing your request');
-                res.redirect('/');
-            } else if (!relay) {
-                req.flash('info', 'The application requested access to unknown scope');
-                res.redirect('/');
-            } else {
-                var https = require('https');
-                const options = {
-                host: 'ext.prod.api.enedis.fr',
+            var https = require('https');
+            const options = {
+                host: relay.targetHost,
                 port: 443,
-                path: '/oauth2/v3/token',
+                path: relay.targetTokenUrl,
                 method: 'POST',
                 headers: {
                     'Accept': 'application/json',
                     'Accept-Encoding': '*',
                     'Content-Type': 'application/x-www-form-urlencoded'
                 }
-                };
+            };
 
-                // Make a request
-                var req2 = https.request(options, function(res2) {
-                    console.log('STATUS: ' + res2.statusCode);
-                    console.log('HEADERS: ' + JSON.stringify(res2.headers));
-                    res2.setEncoding('utf8');
-                    res2.on('data', function (chunk) {
-                    console.log('BODY: ' + chunk);
-                    res.status(200).end(chunk);
+            // Make a request
+            var req2 = https.request(options, function(res2) {
+                res2.setEncoding('utf8');
+                res2.on('data', function (chunk) {
+                    json = JSON.parse(chunk)
+
+                    token = json.access_token;
+                    scope = json.scope;
+                    tokenType = json.token_type;
+                    expiresIn = json.expires_in;
+
+                    return done(null, token, {expires_in: expiresIn, token_type: tokenType, scope:scope});
+                });
+            });
+            
+            req2.on('error', function(e) {
+                console.log('problem with request: ' + e.message);
+            });
+            
+            // write data to request body
+            var clientId = relay.clientId;
+            var clientSecret = relay.clientSecret;
+            req2.write('client_id=' + clientId + '&client_secret=' + clientSecret + '&grant_type=client_credentials');
+            req2.end();
+        }
+    });
+}));
+
+
+
+exports.authorization = [
+        server.authorization(function (clientId, redirectURI, done) {
+        console.log('==================== server.authorization called');
+        console.log('clientId: ' + clientId);
+        console.log('redirectURI: ' + redirectURI);
+
+        OAuth2Client.findOne({
+                        clientId: clientId
+                    }, function (error, client) {
+                        if (error) {
+                            return done(error);
+                        }
+
+                        return done(null, client, redirectURI);
                     });
-                });
-                
-                req2.on('error', function(e) {
-                    console.log('problem with request: ' + e.message);
-                });
-                
-                // write data to request body
-                var clientId = relay.clientId;
-                var clientSecret = relay.clientSecret;
-                req2.write('client_id=' + clientId + '&client_secret=' + clientSecret + '&grant_type=client_credentials');
-                req2.end();
-            }
-        });
-    };
+        }),
+        function (req, res) {
+            var errormessages,
+                        infomessages,
+                        scope,
+                        relay;
+            
+            errormessages = req.flash('error');
+            infomessages = req.flash('info');
+            scope = req.oauth2.req.scope;
+            console.log('server.authorization oauth2 request for scope: ' + scope);
+            relay = scope;
 
+            OAuth2Scope.findOne({
+                        name: scope
+                    }, function (error, scope) {
+                        if (error) {
+                            req.flash('error', 'There was an error while processing your request');
+                            res.redirect('/');
+                        } else if (!scope) {
+                            req.flash('info', 'The application requested access to unknown scope');
+                            res.redirect('/');
+                        } else {
+                            console.log('relay:' + relay);
+                            console.log('scope:' + scope);
+                            OAuth2Relay.findOne({
+                                name: relay
+                            }, function (error, relay) {
+                                if (error) {
+                                    req.flash('error', 'There was an error while processing your request');
+                                    res.redirect('/');
+                                } else if (!relay) {
+                                    req.flash('info', 'The application requested access to unknown scope');
+                                    res.redirect('/');
+                                } else {
+                                    var redirectUri = relay.targetAuthorizeUrl;
+
+                                    redirectUri = redirectUri + "?duration=P36M";
+                                    redirectUri = redirectUri + "&response_type=code";
+                                    redirectUri = redirectUri + "&client_id=" + relay.clientId;
+                                    redirectUri = redirectUri + "&scope=" + "am_application_scope+default";
+                                    
+                                    logger.debug('redirectUri:' + redirectUri);
+                                    res.redirect(redirectUri);
+                                }
+                            });
+                    
+                            
+                        }});
+    }
+];
+
+exports.decision = [
+    server.decision(function (req, done) {
+        console.log('==================== server.decision called');
+        return done(null, {
+            scope: req.oauth2.req.scope
+        });
+    })
+];
+
+exports.token = 
+[
+    passport.authenticate(['oauth2-client-password', 'oAuthBasic'], { session: false }),
+    server.token(),
+    server.errorHandler()    
+];
 


### PR DESCRIPTION
# auth2 proxy

# description

## Introduction
This is a proposal to add a new route /oauth2proxy to openhab-cloud.

The idea behind that is that sometime you would like to access external services that use oauth client credentials flow for authentification. 

But at the same time, you don't want to expose clientId / clientSecret of that service to openhab end user.
(Perhaps because you don't have the legal right for exemple to expose the credentials to end user).

So you will use openhab-cloud as a sort of oAuth2 Proxy relay between the services and your openhab instance.

## How it works
The oAuth2Proxy expose a standard oAuth2 client credentials endpoints.
You will need to have an entry into oauth2clients & oauth2scopes for it.

```
{
      _id: 674b24382f778d464be92e4f
      name : "MyExternelService"
      description: "MyExternalServiceDescription"
      homeUrl: "https://www.myservice.fr"
      icon: "serviceIcon.png"
      clientId: "_8mb0M0hsi_4HMUwhnbmPnTmlw69"
      clientSecret: "JdCK1bH1EDhK3CcQR4sftn99eXAl"
      active: true
      created: ""
      last_change : ""
}
```

```
{
      _id: 674b24d02f778d464be92e51
      name : "MyExternelService"
      description: "MyExternalServiceDescription"
}
```

The clientId & clientSecret will be used on openhab side to authenticate to the proxy as an usual oauth flow using the OAuthClientService.

You will also need to have an entry into the new table oauth2relays:

```
{
      _id: 674c832c2f778d464be92e71
      name : "MyExternelService"
      description: "MyExternalServiceDescription"
      homeUrl: "https://api.myservice.fr/"
      icon: "icon.png"
      clientId: "QzsYYXz8b8aItf1axPITTwhZaroa"
      clientSecret: "rb1WMNoik1iKLn65Ih5O1Tl3gYwa"
      targetTokenUrl: "/oauth2/v3/token"
      targetAuthorizeUrl: "https://myaccount.myservice.fr/dataconnect/v1/oauth2/authorize"
      targetHost: "api.myservice.fr"
}
```

the clientId & clientSecret is this table are the real clientId/clientSecret from the service.

When openhab make a request to the authorize point, we will:
   1. Verify that the clientId is know in the oauth2clients tables.
   2. Construct a redirect URI to the realservice.
   3. Send a redirect to this URI.

When openhab make a request to the token endpoint, we will:
   1. Authenticate the request use the clientId/clientSecret from the oauth2client tables.
   2. Request the service token endpoint in the exchange method to get the real token from the remote service.
   3. Send back this token to openhab.

This new code has been tested today with an existing oAuth service / binding on the openhab side, so it can work.
I would appreciate your comments on this proposal.
Especially if you see security about it, or if you thing for some reason that it's not a good idea.

Thanks,
     Laurent.

