### PR TITLE
Replace uuid dependency with Node.js crypto.randomUUID()

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,6 @@
         "serve-static": "^2.2.1",
         "socket.io": "^4.8.3",
         "underscore": "^1.13.7",
-        "uuid": "^11.1.0",
         "winston": "3.19.0",
         "winston-daily-rotate-file": "^5.0.0",
         "zod": "^4.3.6"
@@ -2137,9 +2136,10 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "4.19.8",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz",
-      "integrity": "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
+      "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -2156,19 +2156,6 @@
       "license": "MIT",
       "dependencies": {
         "@types/express": "*"
-      }
-    },
-    "node_modules/@types/express/node_modules/@types/express-serve-static-core": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
-      "integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*",
-        "@types/qs": "*",
-        "@types/range-parser": "*",
-        "@types/send": "*"
       }
     },
     "node_modules/@types/html-to-text": {
@@ -2410,6 +2397,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
       "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -6883,6 +6871,18 @@
         "@types/express-serve-static-core": "^4.17.33",
         "@types/qs": "*",
         "@types/serve-static": "^1"
+      }
+    },
+    "node_modules/jwks-rsa/node_modules/@types/express-serve-static-core": {
+      "version": "4.19.8",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz",
+      "integrity": "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
       }
     },
     "node_modules/jwks-rsa/node_modules/@types/send": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "serve-static": "^2.2.1",
     "socket.io": "^4.8.3",
     "underscore": "^1.13.7",
-    "uuid": "^11.1.0",
     "winston": "3.19.0",
     "winston-daily-rotate-file": "^5.0.0",
     "zod": "^4.3.6"

--- a/src/models/verification.model.ts
+++ b/src/models/verification.model.ts
@@ -12,7 +12,7 @@
  */
 
 import { Schema, model, Model, Types } from 'mongoose';
-import { v1 as uuidv1 } from 'uuid';
+import { randomUUID } from 'crypto';
 import type {
   IEmailVerification,
   IInvitation,
@@ -53,7 +53,7 @@ emailVerificationSchema.static(
   ): Promise<EmailVerificationDocument> {
     const objectId = typeof userId === 'string' ? new Types.ObjectId(userId) : userId;
     const verification = new this({
-      code: uuidv1(),
+      code: randomUUID(),
       email,
       user: objectId,
     });
@@ -113,7 +113,7 @@ interface InvitationModelStatics {
 
 invitationSchema.static('createInvitation', async function (email: string): Promise<InvitationDocument> {
   const invitation = new this({
-    code: uuidv1(),
+    code: randomUUID(),
     email,
   });
   return invitation.save();
@@ -188,7 +188,7 @@ lostPasswordSchema.static(
     const objectId = typeof userId === 'string' ? new Types.ObjectId(userId) : userId;
     const lostPassword = new this({
       user: objectId,
-      recoveryCode: uuidv1(),
+      recoveryCode: randomUUID(),
     });
     return lostPassword.save();
   }

--- a/src/services/user.service.ts
+++ b/src/services/user.service.ts
@@ -11,7 +11,7 @@
  * SPDX-License-Identifier: EPL-2.0
  */
 
-import { v4 as uuidv4 } from 'uuid';
+import { randomUUID } from 'crypto';
 import type { Types } from 'mongoose';
 import type {
   IUser,
@@ -219,7 +219,7 @@ export class UserService {
         return { success: true };
       }
 
-      const recoveryCode = uuidv4();
+      const recoveryCode = randomUUID();
       await this.lostPasswordRepository.create({
         user: user._id,
         recoveryCode,
@@ -309,7 +309,7 @@ export class UserService {
    * Send email verification to user
    */
   async sendEmailVerification(user: IUser): Promise<void> {
-    const code = uuidv4();
+    const code = randomUUID();
 
     await this.emailVerificationRepository.create({
       user: user._id,

--- a/src/socket/socket-server.ts
+++ b/src/socket/socket-server.ts
@@ -13,7 +13,7 @@
 
 import type { Server as HttpServer } from 'http';
 import { Server as SocketIOServer, type Socket } from 'socket.io';
-import { v1 as uuidv1 } from 'uuid';
+import { randomUUID } from 'crypto';
 import type { Types } from 'mongoose';
 import type { IOpenhab, IUser, IEvent } from '../types/models';
 import type { ILogger, INotificationService, NotificationPayload } from '../types/notification';
@@ -175,7 +175,7 @@ export class SocketServer {
     // Acquire connection lock
     this.io.use(async (socket, next) => {
       const openhabSocket = socket as OpenhabSocket;
-      const connectionId = uuidv1();
+      const connectionId = randomUUID();
       openhabSocket.connectionId = connectionId;
 
       const openhabId = openhabSocket.openhab!._id.toString();


### PR DESCRIPTION
## Summary
- Remove `uuid` package entirely — avoids the ESM-only issue in uuid v12+ (our tsconfig uses CommonJS output)
- Replace `uuidv4()` and `uuidv1()` calls with Node.js built-in `crypto.randomUUID()`
- All usages are for generating unique identifiers (connection IDs, verification codes, recovery codes) — time-based ordering from v1 UUIDs was not needed

Closes #540

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm test` — all 347 unit tests pass
- [x] `npm run test:integration` — all 151 integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)