### PR TITLE
Fix duplicate Mongoose schema index warning on Openhab model

### DIFF
--- a/src/models/openhab.model.ts
+++ b/src/models/openhab.model.ts
@@ -35,7 +35,6 @@ const openhabSchema = new Schema<IOpenhab, OpenhabModel>(
 // Indexes
 // ============================================================================
 
-openhabSchema.index({ uuid: 1 });
 openhabSchema.index({ account: 1 });
 
 // ============================================================================


### PR DESCRIPTION
## Summary
- Remove redundant `openhabSchema.index({ uuid: 1 })` call in `src/models/openhab.model.ts`
- The `unique: true` option on the `uuid` field definition already creates this index and enforces uniqueness
- Eliminates the `[MONGOOSE] Warning: Duplicate schema index on {"uuid":1} for model "Openhab"` warning on startup

## Test plan
- [x] `npm run typecheck` passes
- [ ] Start the app and confirm the duplicate index warning is gone

🤖 Generated with [Claude Code](https://claude.com/claude-code)