### PR TITLE
Add automatic GitHub Release creation on version tag push

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -178,6 +178,12 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Create GitHub Release
+        if: startsWith(github.ref, 'refs/tags/v')
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+
       - name: Create build tag
         if: github.ref == 'refs/heads/main'
         env:


### PR DESCRIPTION
## Summary
- Adds a step to the `docker-publish.yml` workflow that creates a GitHub Release with auto-generated release notes whenever a `v*` tag is pushed
- Uses `softprops/action-gh-release@v2` with `generate_release_notes: true`
- Conditioned on `startsWith(github.ref, 'refs/tags/v')` so it only runs for version tags, not `main` branch pushes

## Test plan
- [ ] Verify the workflow YAML is valid
- [ ] Push a version tag and confirm a GitHub Release is created automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)