### PR TITLE
Redirect unauthenticated browsers on proxy paths to main login

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -139,13 +139,12 @@ export async function createApp(configPath: string): Promise<AppContainer> {
   // Trust proxy for correct client IP and protocol detection behind reverse proxy
   app.set('trust proxy', 1);
 
-  // Configure session cookie (matching original behavior)
-  // Note: We don't set secure/httpOnly/sameSite explicitly to match original app.js
-  // which relied on defaults. This avoids issues with reverse proxies.
   const cookie: session.CookieOptions = {};
   if (config.system.subDomainCookies) {
     cookie.path = '/';
     cookie.domain = '.' + configManager.getHost();
+    cookie.sameSite = 'lax';
+    cookie.secure = true;
     logger.info('Cross sub domain cookie support is configured for domain: ' + cookie.domain);
   }
 
@@ -245,6 +244,7 @@ export async function createApp(configPath: string): Promise<AppContainer> {
   app.use((_req: Request, res: Response, next: NextFunction) => {
     res.locals['baseurl'] = configManager.getBaseURL();
     res.locals['proxyUrl'] = configManager.getProxyURL();
+    res.locals['browserProxyUrl'] = configManager.getBrowserProxyURL() ?? configManager.getProxyURL();
 
     const session = (_req as Request & { session: { timezone?: string } }).session;
     if (session?.timezone) {
@@ -367,6 +367,9 @@ export async function createApp(configPath: string): Promise<AppContainer> {
       getPort: () => configManager.getPort(),
       getProxyHost: () => configManager.getProxyHost(),
       getProxyPort: () => configManager.getProxyPort(),
+      getProxyURL: () => configManager.getProxyURL(),
+      getBrowserProxyHost: () => configManager.getBrowserProxyHost(),
+      getBrowserProxyURL: () => configManager.getBrowserProxyURL(),
     },
     healthController,
     services,

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -123,6 +123,23 @@ export class SystemConfigManager {
   }
 
   /**
+   * Get the configured browser proxy host, if any.
+   * When set, this hostname serves the same proxy content as proxyHost but
+   * redirects unauthenticated browser navigations to the main-site login.
+   */
+  getBrowserProxyHost(): string | undefined {
+    return this.config.system.browserProxyHost;
+  }
+
+  /**
+   * Get the full browser proxy URL, or undefined when not configured.
+   */
+  getBrowserProxyURL(): string | undefined {
+    const host = this.getBrowserProxyHost();
+    return host ? `${this.getProtocol()}://${host}` : undefined;
+  }
+
+  /**
    * Get the port the Node process should listen on
    */
   getNodeProcessPort(): number {

--- a/src/config/schema.ts
+++ b/src/config/schema.ts
@@ -23,7 +23,8 @@ const SystemSchema = z.object({
   protocol: z.enum(['http', 'https']).default('https'),
   proxyHost: z.string().optional(),
   proxyPort: z.coerce.number().int().positive().optional(),
-  subDomainCookies: z.boolean().default(false),
+  browserProxyHost: z.string().optional(),
+  subDomainCookies: z.boolean().default(true),
   muteNotifications: z.boolean().default(false),
   offlineNotificationTime: z.number().default(300000), // 5 minutes in ms
   connectionLockTimeSeconds: z.number().default(70),

--- a/src/middleware/guards.ts
+++ b/src/middleware/guards.ts
@@ -16,6 +16,24 @@ import passport from 'passport';
 import type { UserRole, UserGroup } from '../types/models';
 
 /**
+ * Minimum config shape required by createBrowserAwareAuthenticated.
+ */
+export interface BrowserAwareAuthConfig {
+  getHost(): string;
+}
+
+/**
+ * Minimum config shape required by createApplyReturnTo. Names the set of
+ * hostnames this deployment actively serves; any returnTo that resolves
+ * outside this set is rejected.
+ */
+export interface ReturnToHostConfig {
+  getHost(): string;
+  getProxyHost(): string;
+  getBrowserProxyHost(): string | undefined;
+}
+
+/**
  * Ensure user is authenticated for web requests
  *
  * If not authenticated, redirects to login page with return URL.
@@ -47,6 +65,93 @@ export const ensureRestAuthenticated: RequestHandler = (req, res, next) => {
   // Try Basic or Bearer authentication
   return passport.authenticate(['basic', 'bearer'], { session: false })(req, res, next);
 };
+
+/**
+ * Create a guard that redirects unauthenticated browser navigations to the
+ * main-site login page while leaving API/WebView clients on the HTTP Basic
+ * challenge path.
+ *
+ * A request is treated as a browser navigation when it is a GET and carries
+ * Fetch Metadata headers typical of a top-level document load
+ * (Sec-Fetch-Dest: document or Sec-Fetch-Mode: navigate) or prefers HTML via
+ * content negotiation. XHR, fetch() requests with Accept: application/json,
+ * CORS preflights, and non-idempotent methods fall through to Basic/Bearer
+ * authentication with no behavior change.
+ *
+ * The login target is the main host (configManager.getHost()); the original
+ * absolute URL is passed as an encoded returnTo query parameter for the login
+ * controller to validate against known hosts before honoring.
+ */
+export function createBrowserAwareAuthenticated(
+  configManager: BrowserAwareAuthConfig
+): RequestHandler {
+  return (req, res, next) => {
+    if (req.isAuthenticated()) {
+      return next();
+    }
+
+    // Prefer Fetch Metadata when present. Fall back to content negotiation —
+    // listing 'json' first so clients sending `Accept: */*` (e.g. curl) are
+    // treated as API clients, while browsers (which explicitly include
+    // text/html at quality 1.0) still resolve to 'html'.
+    const looksLikeBrowserNav =
+      req.method === 'GET' &&
+      (req.get('sec-fetch-dest') === 'document' ||
+        req.get('sec-fetch-mode') === 'navigate' ||
+        req.accepts(['json', 'html']) === 'html');
+
+    if (looksLikeBrowserNav) {
+      const proto = req.protocol;
+      const target = `${proto}://${req.hostname}${req.originalUrl}`;
+      return res.redirect(
+        `${proto}://${configManager.getHost()}/login?returnTo=${encodeURIComponent(target)}`
+      );
+    }
+
+    return passport.authenticate(['basic', 'bearer'], { session: false })(req, res, next);
+  };
+}
+
+/**
+ * Create middleware that accepts a returnTo value from query or body and, when
+ * it points at a host this deployment actively serves, persists it as
+ * req.session.returnTo so passport's successReturnToOrRedirect honors it.
+ *
+ * Absolute URLs outside the allowed hostnames are ignored to prevent open
+ * redirects. Invalid URLs are ignored silently.
+ */
+export function createApplyReturnTo(config: ReturnToHostConfig): RequestHandler {
+  return (req, _res, next) => {
+    const fromQuery = req.query['returnTo'];
+    const fromBody = (req.body as Record<string, unknown> | undefined)?.['returnTo'];
+    const candidate =
+      typeof fromQuery === 'string'
+        ? fromQuery
+        : typeof fromBody === 'string'
+          ? fromBody
+          : null;
+
+    if (candidate) {
+      try {
+        const url = new URL(candidate);
+        const hostname = url.hostname.toLowerCase();
+        const allowed = [
+          config.getHost(),
+          config.getProxyHost(),
+          config.getBrowserProxyHost(),
+        ]
+          .filter((h): h is string => typeof h === 'string' && h.length > 0)
+          .map((h) => h.toLowerCase());
+        if (allowed.includes(hostname)) {
+          req.session.returnTo = url.toString();
+        }
+      } catch {
+        // Invalid URL - ignore
+      }
+    }
+    next();
+  };
+}
 
 /**
  * Create a guard that ensures user has a specific role

--- a/src/middleware/vhost.ts
+++ b/src/middleware/vhost.ts
@@ -16,8 +16,12 @@ import type { SystemConfigManager } from '../config';
 
 /**
  * Create vhost detection middleware.
+ *
  * Sets req.isVhostProxy when the hostname matches the configured proxyHost
- * or the "remote.<mainHost>" convention.
+ * or the "remote.<mainHost>" convention. Additionally sets req.isBrowserVhost
+ * (and implies isVhostProxy) when the hostname matches browserProxyHost — the
+ * browser-facing proxy hostname that redirects unauthenticated navigations to
+ * the main-site login instead of returning an HTTP Basic challenge.
  */
 export function createVhostDetection(configManager: SystemConfigManager) {
   return (req: Request, _res: Response, next: NextFunction) => {
@@ -25,10 +29,15 @@ export function createVhostDetection(configManager: SystemConfigManager) {
     if (host) {
       const proxyHost = configManager.getProxyHost().toLowerCase();
       const mainHost = configManager.getHost().toLowerCase();
+      const browserProxyHost = configManager.getBrowserProxyHost()?.toLowerCase();
       if (
         (proxyHost !== mainHost && host === proxyHost) ||
         host === `remote.${mainHost}`
       ) {
+        req.isVhostProxy = true;
+      }
+      if (browserProxyHost && host === browserProxyHost && browserProxyHost !== mainHost) {
+        req.isBrowserVhost = true;
         req.isVhostProxy = true;
       }
     }

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -25,6 +25,7 @@ import type { Server as SocketIOServer } from 'socket.io';
 
 import { createMiddleware, createSetOpenhabForWebhook, createBodySizeLimit, MiddlewareDependencies } from './middleware';
 import type { IWebhookRepositoryForMiddleware, IOpenhabRepositoryForMiddleware } from './middleware';
+import { createBrowserAwareAuthenticated, createApplyReturnTo } from '../middleware/guards';
 import type { AppLogger } from '../lib/logger';
 import type { PromisifiedRedisClient } from '../lib/redis';
 import type { IUser, IInvitation, IOpenhab } from '../types/models';
@@ -493,11 +494,15 @@ export function createRoutes(deps: RoutesDependencies): Router {
   // For non-vhost requests, next('route') skips to normal web routes below.
 
   const proxyRoute = createProxyHandler(io, requestTracker, systemConfig, logger);
+  const ensureBrowserAware = createBrowserAwareAuthenticated(systemConfig);
 
   router.all('/{*path}', (req: Request, _res: Response, next: NextFunction) => {
     if (!req.isVhostProxy) return next('route');
     next();
-  }, ensureRestAuthenticated, setOpenhab, preassembleBody, ensureServer, proxyRoute);
+  }, (req: Request, res: Response, next: NextFunction) => {
+    const guard = req.isBrowserVhost ? ensureBrowserAware : ensureRestAuthenticated;
+    return guard(req, res, next);
+  }, setOpenhab, preassembleBody, ensureServer, proxyRoute);
 
   // ============================================
   // Webhook Proxy Routes (no authentication — UUID is the secret)
@@ -536,9 +541,12 @@ export function createRoutes(deps: RoutesDependencies): Router {
     });
   });
 
-  router.get('/login', (req: Request, res: Response) => {
+  const applyReturnTo = createApplyReturnTo(systemConfig);
+
+  router.get('/login', applyReturnTo, (req: Request, res: Response) => {
     const errormessages = req.flash('error');
     const invitationCode = req.query['invitationCode'] ?? '';
+    const returnTo = typeof req.query['returnTo'] === 'string' ? req.query['returnTo'] : '';
 
     res.render('login', {
       title: 'Log in',
@@ -546,11 +554,13 @@ export function createRoutes(deps: RoutesDependencies): Router {
       errormessages,
       infomessages: req.flash('info'),
       invitationCode,
+      returnTo,
     });
   });
 
   router.post(
     '/login',
+    applyReturnTo,
     validateBody(LoginSchema, { redirectOnError: '/login' }),
     passport.authenticate('local', {
       successReturnToOrRedirect: '/',
@@ -736,7 +746,7 @@ export function createRoutes(deps: RoutesDependencies): Router {
   ];
 
   for (const path of proxyPaths) {
-    router.all(path, ensureRestAuthenticated, setOpenhab, preassembleBody, ensureServer, proxyRoute);
+    router.all(path, ensureBrowserAware, setOpenhab, preassembleBody, ensureServer, proxyRoute);
   }
 
   return router;

--- a/src/routes/middleware.ts
+++ b/src/routes/middleware.ts
@@ -114,6 +114,9 @@ export interface MiddlewareDependencies {
     getPort(): number;
     getProxyHost(): string;
     getProxyPort(): number;
+    getProxyURL(): string;
+    getBrowserProxyHost(): string | undefined;
+    getBrowserProxyURL(): string | undefined;
   };
 }
 

--- a/src/types/express.d.ts
+++ b/src/types/express.d.ts
@@ -35,6 +35,13 @@ declare global {
       isVhostProxy?: boolean;
 
       /**
+       * True when the request arrived via the browser-facing proxy hostname.
+       * Implies isVhostProxy; unauthenticated navigations redirect to login
+       * instead of returning an HTTP Basic challenge.
+       */
+      isBrowserVhost?: boolean;
+
+      /**
        * The authenticated user's openHAB instance
        */
       openhab?: IOpenhab;

--- a/tests/mocha/unit/middleware/guards.test.ts
+++ b/tests/mocha/unit/middleware/guards.test.ts
@@ -1,0 +1,330 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+import { expect } from 'chai';
+import sinon from 'sinon';
+import type { Request, Response, NextFunction } from 'express';
+import passport from 'passport';
+import {
+  createBrowserAwareAuthenticated,
+  createApplyReturnTo,
+} from '../../../../src/middleware/guards';
+
+interface MockReqInput {
+  method?: string;
+  headers?: Record<string, string>;
+  hostname?: string;
+  originalUrl?: string;
+  protocol?: string;
+  authenticated?: boolean;
+  query?: Record<string, unknown>;
+  body?: Record<string, unknown>;
+  session?: Record<string, unknown>;
+}
+
+function buildReq(input: MockReqInput = {}): Request {
+  const headers = input.headers ?? {};
+  const lowered: Record<string, string> = {};
+  for (const [k, v] of Object.entries(headers)) {
+    lowered[k.toLowerCase()] = v;
+  }
+  // Minimal shim matching Express's req.accepts for the headers we actually
+  // exercise here. When Accept is */*  or missing, both types match equally
+  // and the first entry of the preference list wins — mirroring Express's
+  // quality-based ordering.
+  const accepts = (types: string | string[]) => {
+    const arr = Array.isArray(types) ? types : [types];
+    const accept = lowered['accept'];
+    if (!accept || accept.includes('*/*')) return arr[0] ?? false;
+    const wantsHtml = accept.includes('text/html');
+    const wantsJson = accept.includes('application/json');
+    for (const t of arr) {
+      if (t === 'html' && wantsHtml) return 'html';
+      if (t === 'json' && wantsJson) return 'json';
+    }
+    return false;
+  };
+
+  return {
+    method: input.method ?? 'GET',
+    hostname: input.hostname ?? 'connect.example.com',
+    originalUrl: input.originalUrl ?? '/',
+    protocol: input.protocol ?? 'https',
+    isAuthenticated: () => Boolean(input.authenticated),
+    query: input.query ?? {},
+    body: input.body ?? {},
+    session: input.session ?? {},
+    get: (name: string) => lowered[name.toLowerCase()],
+    accepts,
+  } as unknown as Request;
+}
+
+function buildRes(): { res: Response; redirectSpy: sinon.SinonSpy; statusSpy: sinon.SinonSpy } {
+  const redirectSpy = sinon.spy();
+  const statusSpy = sinon.spy(() => ({ end: sinon.spy(), send: sinon.spy() }));
+  const res = {
+    redirect: redirectSpy,
+    status: statusSpy,
+  } as unknown as Response;
+  return { res, redirectSpy, statusSpy };
+}
+
+describe('createBrowserAwareAuthenticated', () => {
+  const config = { getHost: () => 'mycloud.example.com' };
+  let passportStub: sinon.SinonStub;
+
+  beforeEach(() => {
+    // Stub passport.authenticate to track delegation to Basic/Bearer
+    passportStub = sinon.stub(passport, 'authenticate').returns(((
+      _req: Request,
+      _res: Response,
+      next: NextFunction
+    ) => {
+      next();
+    }) as unknown as ReturnType<typeof passport.authenticate>);
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('calls next when already authenticated, without touching Passport', () => {
+    const guard = createBrowserAwareAuthenticated(config);
+    const req = buildReq({ authenticated: true });
+    const { res } = buildRes();
+    const next = sinon.spy();
+
+    guard(req, res, next);
+
+    expect(next.calledOnce).to.be.true;
+    expect(passportStub.called).to.be.false;
+  });
+
+  it('redirects GET with Sec-Fetch-Dest: document to main-site login', () => {
+    const guard = createBrowserAwareAuthenticated(config);
+    const req = buildReq({
+      method: 'GET',
+      hostname: 'connect.example.com',
+      originalUrl: '/basicui/app',
+      headers: { 'sec-fetch-dest': 'document' },
+    });
+    const { res, redirectSpy } = buildRes();
+    const next = sinon.spy();
+
+    guard(req, res, next);
+
+    expect(next.called).to.be.false;
+    expect(passportStub.called).to.be.false;
+    expect(redirectSpy.calledOnce).to.be.true;
+    const target = redirectSpy.firstCall.args[0] as string;
+    expect(target).to.include('https://mycloud.example.com/login?returnTo=');
+    const returnTo = decodeURIComponent(target.split('returnTo=')[1]!);
+    expect(returnTo).to.equal('https://connect.example.com/basicui/app');
+  });
+
+  it('redirects GET with Sec-Fetch-Mode: navigate', () => {
+    const guard = createBrowserAwareAuthenticated(config);
+    const req = buildReq({
+      method: 'GET',
+      headers: { 'sec-fetch-mode': 'navigate' },
+    });
+    const { res, redirectSpy } = buildRes();
+
+    guard(req, res, sinon.spy());
+
+    expect(redirectSpy.calledOnce).to.be.true;
+  });
+
+  it('redirects GET with Accept: text/html when Sec-Fetch-* absent', () => {
+    const guard = createBrowserAwareAuthenticated(config);
+    const req = buildReq({
+      method: 'GET',
+      headers: { accept: 'text/html,application/xhtml+xml' },
+    });
+    const { res, redirectSpy } = buildRes();
+
+    guard(req, res, sinon.spy());
+
+    expect(redirectSpy.calledOnce).to.be.true;
+  });
+
+  it('delegates to Passport when Accept is application/json', () => {
+    const guard = createBrowserAwareAuthenticated(config);
+    const req = buildReq({
+      method: 'GET',
+      headers: { accept: 'application/json' },
+    });
+    const { res, redirectSpy } = buildRes();
+    const next = sinon.spy();
+
+    guard(req, res, next);
+
+    expect(redirectSpy.called).to.be.false;
+    expect(passportStub.calledOnceWith(['basic', 'bearer'], { session: false })).to.be.true;
+  });
+
+  it('delegates to Passport for POST regardless of Accept', () => {
+    const guard = createBrowserAwareAuthenticated(config);
+    const req = buildReq({
+      method: 'POST',
+      headers: { accept: 'text/html', 'sec-fetch-dest': 'document' },
+    });
+    const { res, redirectSpy } = buildRes();
+
+    guard(req, res, sinon.spy());
+
+    expect(redirectSpy.called).to.be.false;
+    expect(passportStub.calledOnce).to.be.true;
+  });
+
+  it('delegates to Passport for GET with no browser navigation signals', () => {
+    const guard = createBrowserAwareAuthenticated(config);
+    const req = buildReq({ method: 'GET', headers: {} });
+    const { res, redirectSpy } = buildRes();
+
+    guard(req, res, sinon.spy());
+
+    expect(redirectSpy.called).to.be.false;
+    expect(passportStub.calledOnce).to.be.true;
+  });
+
+  it("delegates to Passport for curl-style Accept: */*", () => {
+    const guard = createBrowserAwareAuthenticated(config);
+    const req = buildReq({ method: 'GET', headers: { accept: '*/*' } });
+    const { res, redirectSpy } = buildRes();
+
+    guard(req, res, sinon.spy());
+
+    expect(redirectSpy.called).to.be.false;
+    expect(passportStub.calledOnce).to.be.true;
+  });
+});
+
+describe('createApplyReturnTo', () => {
+  const config = {
+    getHost: () => 'mycloud.example.com',
+    getProxyHost: () => 'home.example.com',
+    getBrowserProxyHost: () => 'connect.example.com' as string | undefined,
+  };
+
+  it('accepts an absolute URL to the main host', () => {
+    const handler = createApplyReturnTo(config);
+    const session: Record<string, unknown> = {};
+    const req = buildReq({
+      query: { returnTo: 'https://mycloud.example.com/account' },
+      session,
+    });
+    const { res } = buildRes();
+    const next = sinon.spy();
+
+    handler(req, res, next);
+
+    expect(session['returnTo']).to.equal('https://mycloud.example.com/account');
+    expect(next.calledOnce).to.be.true;
+  });
+
+  it('accepts an absolute URL to the proxy host', () => {
+    const handler = createApplyReturnTo(config);
+    const session: Record<string, unknown> = {};
+    const req = buildReq({
+      query: { returnTo: 'https://home.example.com/rest/items' },
+      session,
+    });
+
+    handler(req, buildRes().res, sinon.spy());
+
+    expect(session['returnTo']).to.equal('https://home.example.com/rest/items');
+  });
+
+  it('accepts an absolute URL to the browser proxy host', () => {
+    const handler = createApplyReturnTo(config);
+    const session: Record<string, unknown> = {};
+    const req = buildReq({
+      query: { returnTo: 'https://connect.example.com/basicui/app' },
+      session,
+    });
+
+    handler(req, buildRes().res, sinon.spy());
+
+    expect(session['returnTo']).to.equal('https://connect.example.com/basicui/app');
+  });
+
+  it('rejects absolute URLs to unrelated hosts', () => {
+    const handler = createApplyReturnTo(config);
+    const session: Record<string, unknown> = {};
+    const req = buildReq({
+      query: { returnTo: 'https://evil.example.com/phish' },
+      session,
+    });
+
+    handler(req, buildRes().res, sinon.spy());
+
+    expect(session['returnTo']).to.be.undefined;
+  });
+
+  it('ignores malformed URLs silently', () => {
+    const handler = createApplyReturnTo(config);
+    const session: Record<string, unknown> = {};
+    const req = buildReq({
+      query: { returnTo: 'not-a-url' },
+      session,
+    });
+
+    handler(req, buildRes().res, sinon.spy());
+
+    expect(session['returnTo']).to.be.undefined;
+  });
+
+  it('reads returnTo from the request body when not in query', () => {
+    const handler = createApplyReturnTo(config);
+    const session: Record<string, unknown> = {};
+    const req = buildReq({
+      body: { returnTo: 'https://connect.example.com/path' },
+      session,
+    });
+
+    handler(req, buildRes().res, sinon.spy());
+
+    expect(session['returnTo']).to.equal('https://connect.example.com/path');
+  });
+
+  it('treats hostname comparison as case-insensitive', () => {
+    const handler = createApplyReturnTo(config);
+    const session: Record<string, unknown> = {};
+    const req = buildReq({
+      query: { returnTo: 'https://Connect.Example.Com/foo' },
+      session,
+    });
+
+    handler(req, buildRes().res, sinon.spy());
+
+    expect(session['returnTo']).to.equal('https://connect.example.com/foo');
+  });
+
+  it('does not trust a browser proxy host match when none is configured', () => {
+    const handler = createApplyReturnTo({
+      getHost: () => 'mycloud.example.com',
+      getProxyHost: () => 'home.example.com',
+      getBrowserProxyHost: () => undefined,
+    });
+    const session: Record<string, unknown> = {};
+    const req = buildReq({
+      query: { returnTo: 'https://connect.example.com/x' },
+      session,
+    });
+
+    handler(req, buildRes().res, sinon.spy());
+
+    expect(session['returnTo']).to.be.undefined;
+  });
+});

--- a/tests/mocha/unit/routes/middleware.test.ts
+++ b/tests/mocha/unit/routes/middleware.test.ts
@@ -48,10 +48,14 @@ describe('Route Middleware', () => {
 
     mockSystemConfig = {
       getInternalAddress: () => 'server1.internal:3000',
+      getBaseURL: () => 'https://localhost',
       getHost: () => 'localhost',
       getPort: () => 3000,
       getProxyHost: () => 'proxy.local',
       getProxyPort: () => 8080,
+      getProxyURL: () => 'https://proxy.local',
+      getBrowserProxyHost: () => undefined,
+      getBrowserProxyURL: () => undefined,
     };
 
     deps = {

--- a/tests/mocha/unit/routes/vhost-detection.test.ts
+++ b/tests/mocha/unit/routes/vhost-detection.test.ts
@@ -18,7 +18,7 @@ import { createVhostDetection } from '../../../../src/middleware/vhost';
 import type { SystemConfigManager } from '../../../../src/config';
 
 describe('Vhost Detection Middleware', () => {
-  let mockConfigManager: Pick<SystemConfigManager, 'getProxyHost' | 'getHost'>;
+  let mockConfigManager: Pick<SystemConfigManager, 'getProxyHost' | 'getHost' | 'getBrowserProxyHost'>;
   let mockRes: Response;
   let nextSpy: sinon.SinonSpy;
 
@@ -32,7 +32,7 @@ describe('Vhost Detection Middleware', () => {
   });
 
   function createReq(hostname: string | undefined): Request {
-    return { hostname, isVhostProxy: undefined } as unknown as Request;
+    return { hostname, isVhostProxy: undefined, isBrowserVhost: undefined } as unknown as Request;
   }
 
   describe('when proxyHost differs from mainHost', () => {
@@ -40,6 +40,7 @@ describe('Vhost Detection Middleware', () => {
       mockConfigManager = {
         getProxyHost: () => 'proxy.example.com',
         getHost: () => 'mycloud.example.com',
+        getBrowserProxyHost: () => undefined,
       };
     });
 
@@ -89,6 +90,7 @@ describe('Vhost Detection Middleware', () => {
       mockConfigManager = {
         getProxyHost: () => 'mycloud.example.com',
         getHost: () => 'mycloud.example.com',
+        getBrowserProxyHost: () => undefined,
       };
     });
 
@@ -118,6 +120,7 @@ describe('Vhost Detection Middleware', () => {
       mockConfigManager = {
         getProxyHost: () => 'proxy.example.com',
         getHost: () => 'mycloud.example.com',
+        getBrowserProxyHost: () => undefined,
       };
     });
 
@@ -145,6 +148,7 @@ describe('Vhost Detection Middleware', () => {
       mockConfigManager = {
         getProxyHost: () => 'proxy.example.com',
         getHost: () => 'mycloud.example.com',
+        getBrowserProxyHost: () => undefined,
       };
     });
 
@@ -174,6 +178,58 @@ describe('Vhost Detection Middleware', () => {
       middleware(req3, mockRes, nextSpy);
 
       expect(nextSpy.callCount).to.equal(3);
+    });
+  });
+
+  describe('browser proxy host detection', () => {
+    beforeEach(() => {
+      mockConfigManager = {
+        getProxyHost: () => 'proxy.example.com',
+        getHost: () => 'mycloud.example.com',
+        getBrowserProxyHost: () => 'connect.example.com',
+      };
+    });
+
+    it('should set isBrowserVhost AND isVhostProxy when hostname matches browserProxyHost', () => {
+      const middleware = createVhostDetection(mockConfigManager as SystemConfigManager);
+      const req = createReq('connect.example.com');
+
+      middleware(req, mockRes, nextSpy);
+
+      expect(req.isBrowserVhost).to.equal(true);
+      expect(req.isVhostProxy).to.equal(true);
+    });
+
+    it('should match browserProxyHost case-insensitively', () => {
+      const middleware = createVhostDetection(mockConfigManager as SystemConfigManager);
+      const req = createReq('Connect.Example.Com');
+
+      middleware(req, mockRes, nextSpy);
+
+      expect(req.isBrowserVhost).to.equal(true);
+    });
+
+    it('should not set isBrowserVhost when browserProxyHost matches mainHost', () => {
+      mockConfigManager = {
+        getProxyHost: () => 'proxy.example.com',
+        getHost: () => 'mycloud.example.com',
+        getBrowserProxyHost: () => 'mycloud.example.com',
+      };
+      const middleware = createVhostDetection(mockConfigManager as SystemConfigManager);
+      const req = createReq('mycloud.example.com');
+
+      middleware(req, mockRes, nextSpy);
+
+      expect(req.isBrowserVhost).to.be.undefined;
+    });
+
+    it('should not set isBrowserVhost for unrelated hosts', () => {
+      const middleware = createVhostDetection(mockConfigManager as SystemConfigManager);
+      const req = createReq('evil.example.com');
+
+      middleware(req, mockRes, nextSpy);
+
+      expect(req.isBrowserVhost).to.be.undefined;
     });
   });
 });

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -60,17 +60,17 @@
                     switch (openhabMajorVersion){
                         case 1:
         %>
-                            To remotely access your openHAB's web interface go to <code><%=proxyUrl%>/openhab.app?sitemap=yoursitemapname</code>
+                            To remotely access your openHAB's web interface go to <code><%=browserProxyUrl%>/openhab.app?sitemap=yoursitemapname</code>
         <%
                             break;
                         case 2:
         %>
-                            Your openHAB is online. <a href="<%=proxyUrl%>/start/index">Click here to access your openHAB's dashboard</a>
+                            Your openHAB is online. <a href="<%=browserProxyUrl%>/start/index">Click here to access your openHAB's dashboard</a>
         <%
                             break;
                         default:
         %>
-                            Your openHAB is online. <a href="<%=proxyUrl%>/">Click here to access your openHAB's dashboard</a>
+                            Your openHAB is online. <a href="<%=browserProxyUrl%>/">Click here to access your openHAB's dashboard</a>
         <%
                     }
                     break;

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -9,6 +9,9 @@
                 <h3 class="card-title">Sign In</h3>
                 <form method="post" action="/login">
                     <input type="hidden" name="_csrf" value="<%= token %>">
+                    <% if (returnTo) { %>
+                    <input type="hidden" name="returnTo" value="<%= returnTo %>">
+                    <% } %>
                     <div class="form-group">
                         <label for="username" class="form-label">Email</label>
                         <input type="email" class="form-control" name="username" id="username" placeholder="Email">


### PR DESCRIPTION
## Summary

Unauthenticated browser navigations to the openHAB UI proxy paths (`/basicui`, `/paperui`, `/habpanel`, `/habmin`, `/classicui`, `/start`, `/chart`, etc.) currently hit the native HTTP Basic dialog. This PR redirects those top-level document navigations to the main-site `/login?returnTo=…` and bounces back after sign-in, without changing the 401 Basic path that the openHAB iOS/Android WebViews rely on.

Key changes:

- **`createBrowserAwareAuthenticated`** (`src/middleware/guards.ts`): GET + Fetch Metadata (`Sec-Fetch-Dest: document` / `Sec-Fetch-Mode: navigate`) or explicit `Accept: text/html` → 302 to login. Everything else (Accept: application/json, `*/*`, POST, etc.) falls through to the existing `passport.authenticate(['basic','bearer'])`.
- **`createApplyReturnTo`** (`src/middleware/guards.ts`): strictly validates the `returnTo` URL hostname against `getHost()`, `getProxyHost()`, and `getBrowserProxyHost()` before writing it to `req.session.returnTo` — closes any open-redirect concern.
- **New `browserProxyHost` config** + vhost-detection flag: when set (e.g. `connect.myopenhab.org`), that hostname serves the same proxy content but routes unauthenticated browser navigations through the new guard. The existing `proxyHost` (e.g. `home.myopenhab.org`) keeps its 401-Basic behavior so the mobile WebViews' `onReceivedHttpAuthRequest` / `URLAuthenticationChallenge` handlers still fire.
- **Root-host UI proxy paths** (`src/routes/index.ts:731-740`) now use the new guard. `/api/v1/*`, `/ws/*`, `/addAndroidRegistration*`, `/addIosRegistration*` keep `ensureRestAuthenticated` unchanged.
- **Session cookie defaults** (`src/app.ts`): `subDomainCookies` defaults to `true`, and when enabled the cookie is set with `SameSite=Lax` + `Secure` so the main-site login session flows across subdomains.
- **Views**: `index.ejs` dashboard links now use `browserProxyUrl` (falls back to `proxyUrl`); `login.ejs` forwards `returnTo` via a hidden field through the POST.

## Why the signals are safe

Mobile WebViews look like browsers at the header level, which is why we never change behavior on `proxyHost` itself. On the main host and `browserProxyHost`, the openHAB apps never load through a WebView — the iOS app resolves the cloud URL via `/api/v1/proxyurl` (→ `proxyHost`) and the Android app behaves the same. REST/WebSocket traffic from the apps uses OkHttp/URLSession with `Accept: application/json`, which delegates to Basic/Bearer. The `['json', 'html']` argument order to `req.accepts` also makes `Accept: */*` (curl default) resolve to 'json', so scripted clients retain the 401 Basic path.

## Test plan

- [x] `npm run typecheck`
- [x] `npm test` — 412 passing, including new `createBrowserAwareAuthenticated` and `createApplyReturnTo` unit tests and additional `vhost-detection` tests for `browserProxyHost`
- [ ] Manual: browser hits `{mainHost}/basicui/app` unauthenticated → 302 to login → bounces back after login
- [ ] Manual: browser hits `{browserProxyHost}/` unauthenticated → 302 to login → bounces back
- [ ] Manual: `curl -H 'Accept: application/json' {mainHost}/rest/items` → 401 `WWW-Authenticate: Basic` (unchanged)
- [ ] Manual: `curl {mainHost}/basicui/app` (no Accept) → 401 Basic (curl's `*/*` resolves to 'json' in the preference list — unchanged behavior)
- [ ] Manual: openHAB Android/iOS cold-start MainUI on `{proxyHost}` → still auto-authenticates via 401 Basic (no regression)

## Deployment note

To enable the browser-friendly hostname, add `browserProxyHost` to `config.json` (e.g. `"browserProxyHost": "connect.myopenhab.org"`) and register DNS / extend the TLS SAN for the new host. Without it, only the root-host UI proxy paths pick up the new redirect behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)