### PR TITLE
Fix ReferenceError on /register validation failure

### DIFF
--- a/src/controllers/account.controller.ts
+++ b/src/controllers/account.controller.ts
@@ -392,11 +392,13 @@ export class AccountController {
   // =========================================================================
 
   private renderLogin(req: Request, res: any): void {
+    const returnTo = typeof req.query['returnTo'] === 'string' ? req.query['returnTo'] : '';
     res.render('login', {
       title: 'Login / Sign up',
       user: req.user,
       errormessages: req.flash('error'),
       infomessages: req.flash('info'),
+      returnTo,
     });
   }
 }

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -9,7 +9,7 @@
                 <h3 class="card-title">Sign In</h3>
                 <form method="post" action="/login">
                     <input type="hidden" name="_csrf" value="<%= token %>">
-                    <% if (returnTo) { %>
+                    <% if (typeof returnTo !== 'undefined' && returnTo) { %>
                     <input type="hidden" name="returnTo" value="<%= returnTo %>">
                     <% } %>
                     <div class="form-group">


### PR DESCRIPTION
When the /register handler renders the login page (legal-terms not agreed, or registration error), the EJS 4.x strict locals model throws 'returnTo is not defined' at views/login.ejs:12 because the template references returnTo and the renderLogin helper doesn't pass it.

Two-part fix:
- views/login.ejs: guard the hidden input with a typeof check (typeof returnTo !== 'undefined' && returnTo) so the template survives any caller that omits the local. Matches the defensive style used elsewhere (see views/_register-form.ejs).
- src/controllers/account.controller.ts: pass returnTo from the request query string through renderLogin, so the value round-trips through a failed registration attempt.