### PR TITLE
Fix SSE streaming through the internal cross-node proxy

### DIFF
--- a/src/routes/middleware.ts
+++ b/src/routes/middleware.ts
@@ -42,8 +42,12 @@ const connectionCache = new Map<string, ConnectionCacheEntry>();
 // Default cache TTL: 10 seconds
 const CONNECTION_CACHE_TTL_MS = 10 * 1000;
 
-// Timeout for internal proxy requests (ms)
-const INTERNAL_PROXY_TIMEOUT_MS = 5000;
+// Idle timeout for internal proxy requests (ms). Guards connection setup and
+// time-to-first-byte so a dead/unreachable target node fails fast. It is
+// cleared once the upstream response begins streaming (see proxyToServer) so
+// long-lived streaming responses (SSE: /rest/events, /rest/events/states) that
+// sit quiet between events are not torn down.
+const INTERNAL_PROXY_TIMEOUT_MS = 10000;
 
 // Cleanup interval: run every 60 seconds
 const CACHE_CLEANUP_INTERVAL_MS = 60 * 1000;
@@ -320,6 +324,11 @@ export function createMiddleware(deps: MiddlewareDependencies): RouteMiddleware 
         timeout: INTERNAL_PROXY_TIMEOUT_MS,
       },
       (proxyRes) => {
+        // The upstream response has started. Disable the idle timeout so
+        // long-lived streaming responses (SSE) that go quiet between events
+        // are not destroyed mid-stream; teardown is handled by the client
+        // disconnect (res 'close') and the orphaned-request cleanup instead.
+        proxyReq.setTimeout(0);
         if (res.headersSent) {
           proxyRes.resume(); // drain response to free resources
           return;
@@ -334,6 +343,17 @@ export function createMiddleware(deps: MiddlewareDependencies): RouteMiddleware 
     });
 
     proxyReq.on('error', onError);
+
+    // Tear down the internal proxy request if the client disconnects. The idle
+    // timeout is cleared once the response starts streaming (see above), so for
+    // long-lived streaming responses (SSE) this is what reaps the upstream
+    // connection when the client goes away — .pipe() does not propagate the
+    // client-side close to destroy the source request.
+    res.on('close', () => {
+      if (!proxyReq.destroyed) {
+        proxyReq.destroy();
+      }
+    });
 
     // Body was already consumed by preassembleBody middleware for most proxy
     // routes. WebSocket upgrade routes (/ws/*) have no body.

--- a/tests/mocha/unit/routes/middleware.test.ts
+++ b/tests/mocha/unit/routes/middleware.test.ts
@@ -336,7 +336,7 @@ describe('Route Middleware', () => {
         rawBody: undefined,
       } as unknown as Request;
 
-      const mockRes = {} as unknown as Response;
+      const mockRes = { on: sinon.stub() } as unknown as Response;
       const nextSpy = sinon.spy();
 
       const mockProxyReq = {
@@ -373,7 +373,7 @@ describe('Route Middleware', () => {
         rawBody: 'ON',
       } as unknown as Request;
 
-      const mockRes = {} as unknown as Response;
+      const mockRes = { on: sinon.stub() } as unknown as Response;
       const nextSpy = sinon.spy();
 
       const mockProxyReq = {


### PR DESCRIPTION
## Problem

Server-Sent Events (SSE) proxied through the cloud — e.g. `GET /rest/events/states` and `/rest/events` — close after the first event instead of staying open.

The cloud runs multiple node processes behind nginx, which routes proxied requests to the node holding the openHAB Socket.IO connection via the `CloudServer` affinity cookie. A client **without** that cookie (any first request, a REST/CLI client, etc.) is round-robined to an arbitrary node. When that node isn't the one holding the connection, `ensureServer` re-proxies the request internally to the correct node via `proxyToServer()`.

That internal `http.request` was created with `timeout: 5000`. Node applies the `timeout` option as a **socket idle timeout for the life of the connection**, not just connection setup. So a long-lived streaming response that goes quiet between events (e.g. an unsubscribed states stream between heartbeats) tripped the 5s idle timeout, the internal request was destroyed, and the whole stream collapsed — the client saw the connection drop shortly after the first event.

## Fix

All in `proxyToServer` (`src/routes/middleware.ts`):

1. **Clear the idle timeout once the upstream response begins streaming** (`proxyReq.setTimeout(0)` in the response callback). The timeout now only guards connection setup / time-to-first-byte, so a dead or unreachable target node still fails fast, but a healthy streaming response is no longer torn down between events.
2. **Bump the timeout 5s → 10s** — the 5s connect/first-byte budget was aggressive for a busy target node.
3. **Destroy the internal proxy request when the client disconnects** (`res.on('close')`). `.pipe()` does not propagate the client-side close to the source request, so with the idle timeout gone this is what reaps the upstream connection when the client goes away — making teardown deterministic and immediate rather than relying on any idle timeout.

## Testing

- `npm run typecheck` — clean
- Existing `ensureServer` unit tests pass (two mock `res` fixtures updated to include an `on` stub, since the real Express `Response` is an EventEmitter).
- Verified against a live deployment: with the fix, `GET /rest/events/states` proxied through a node that internally re-proxies to the connection-holding node stays open across heartbeat gaps; without it the stream dropped ~5s after the last event.