### PR TITLE
Proxy WebSocket upgrades across cloud nodes

### DIFF
--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -23,7 +23,7 @@ import passport from 'passport';
 import { Types } from 'mongoose';
 import type { Server as SocketIOServer } from 'socket.io';
 
-import { createMiddleware, createSetOpenhabForWebhook, createBodySizeLimit, requireWellKnownDoc, appendWellKnownPath, MiddlewareDependencies } from './middleware';
+import { createMiddleware, createSetOpenhabForWebhook, createBodySizeLimit, requireWellKnownDoc, appendWellKnownPath, isWebSocketUpgrade, MiddlewareDependencies } from './middleware';
 import type { IWebhookRepositoryForMiddleware, IOpenhabRepositoryForMiddleware } from './middleware';
 import { createLoginRedirectAuthenticated, createApplyReturnTo } from '../middleware/guards';
 import type { AppLogger } from '../lib/logger';
@@ -825,13 +825,7 @@ function createProxyHandlerBase(
     }
 
     // Check if this is a WebSocket upgrade request
-    let isUpgrade = false;
-    if (supportWebSocket) {
-      // Also detect via sec-websocket-* headers which survive reverse proxies
-      // that strip hop-by-hop headers (Upgrade, Connection)
-      isUpgrade = req.headers['upgrade']?.toLowerCase() === 'websocket'
-        || (req.headers['sec-websocket-key'] != null && req.headers['sec-websocket-version'] != null);
-    }
+    const isUpgrade = supportWebSocket && isWebSocketUpgrade(req);
 
     // Always remove cookies (may contain cloud session credentials).
     // For webhook proxying, forward only Authorization since the caller

--- a/src/routes/middleware.ts
+++ b/src/routes/middleware.ts
@@ -18,6 +18,7 @@
  */
 
 import http from 'http';
+import type { Socket as NetSocket } from 'net';
 import type { Request, Response, NextFunction, RequestHandler } from 'express';
 import passport from 'passport';
 import type { PromisifiedRedisClient } from '../lib/redis';
@@ -64,6 +65,17 @@ const cleanupTimer = setInterval(() => {
   }
 }, CACHE_CLEANUP_INTERVAL_MS);
 cleanupTimer.unref();
+
+/**
+ * True if this request is a WebSocket upgrade.
+ *
+ * The sec-websocket-* headers are checked as well because a reverse proxy in
+ * front of us may strip the hop-by-hop Upgrade/Connection headers.
+ */
+export function isWebSocketUpgrade(req: Request): boolean {
+  return req.headers['upgrade']?.toLowerCase() === 'websocket'
+    || (req.headers['sec-websocket-key'] != null && req.headers['sec-websocket-version'] != null);
+}
 
 /**
  * Invalidate connection cache for an openHAB instance
@@ -324,6 +336,11 @@ export function createMiddleware(deps: MiddlewareDependencies): RouteMiddleware 
       `Internal proxy to ${targetAddress} (current: ${systemConfig.getInternalAddress()})`
     );
 
+    // Once the WebSocket tunnel is up the sockets own their own lifecycle:
+    // proxyReq is detached, so neither client disconnects nor late errors
+    // should tear anything down through the HTTP paths below.
+    let upgraded = false;
+
     const proxyReq = http.request(
       {
         hostname: targetHost,
@@ -348,11 +365,80 @@ export function createMiddleware(deps: MiddlewareDependencies): RouteMiddleware 
       }
     );
 
+    // WebSocket upgrades: the target node answers 101 and Node emits 'upgrade'
+    // instead of 'response'. Without this listener Node destroys the socket,
+    // so WebSockets only worked when the client happened to land on the node
+    // holding the openHAB connection.
+    if (isWebSocketUpgrade(req)) {
+      proxyReq.on('upgrade', (proxyRes, upstreamSocket, upstreamHead) => {
+        proxyReq.setTimeout(0);
+        upgraded = true;
+
+        const clientSocket = res.socket;
+        if (!clientSocket || clientSocket.destroyed) {
+          upstreamSocket.destroy();
+          return;
+        }
+
+        // When the upgrade reached us through Express (a reverse proxy stripped
+        // the hop-by-hop headers so server.on('upgrade') never fired), the HTTP
+        // parser is still listening and would read WebSocket frames as HTTP.
+        clientSocket.removeAllListeners('data');
+        const httpResponse = res as unknown as http.ServerResponse;
+        if (typeof httpResponse.detachSocket === 'function') {
+          httpResponse.detachSocket(clientSocket);
+        }
+
+        // rawHeaders keeps the origin node's casing and order intact
+        let rawResponse = `HTTP/1.1 ${proxyRes.statusCode} ${proxyRes.statusMessage || 'Switching Protocols'}\r\n`;
+        for (let i = 0; i < proxyRes.rawHeaders.length; i += 2) {
+          rawResponse += `${proxyRes.rawHeaders[i]}: ${proxyRes.rawHeaders[i + 1]}\r\n`;
+        }
+        rawResponse += '\r\n';
+        clientSocket.write(rawResponse);
+
+        // Tells the synthetic ServerResponse's 'finish' handler in app.ts to
+        // leave this socket alone — it belongs to the tunnel now.
+        (clientSocket as NetSocket & { __upgraded?: boolean }).__upgraded = true;
+
+        if (upstreamHead && upstreamHead.length > 0) {
+          upstreamSocket.unshift(upstreamHead);
+        }
+
+        clientSocket.setTimeout(0);
+        upstreamSocket.setTimeout(0);
+        clientSocket.setNoDelay(true);
+        upstreamSocket.setNoDelay(true);
+
+        clientSocket.pipe(upstreamSocket);
+        upstreamSocket.pipe(clientSocket);
+
+        let closed = false;
+        const teardown = (reason: string) => {
+          if (closed) return;
+          closed = true;
+          logger.debug(`Internal WebSocket proxy to ${targetAddress} closed (${reason})`);
+          clientSocket.destroy();
+          upstreamSocket.destroy();
+        };
+
+        clientSocket.on('close', () => teardown('client close'));
+        clientSocket.on('error', (err) => teardown(`client error: ${err.message}`));
+        upstreamSocket.on('close', () => teardown('upstream close'));
+        upstreamSocket.on('error', (err) => teardown(`upstream error: ${err.message}`));
+
+        logger.info(`Internal WebSocket proxy established to ${targetAddress}`);
+      });
+    }
+
     proxyReq.on('timeout', () => {
       proxyReq.destroy(new Error('proxy timeout'));
     });
 
-    proxyReq.on('error', onError);
+    proxyReq.on('error', (err) => {
+      if (upgraded) return;
+      onError(err);
+    });
 
     // Tear down the internal proxy request if the client disconnects. The idle
     // timeout is cleared once the response starts streaming (see above), so for
@@ -360,7 +446,7 @@ export function createMiddleware(deps: MiddlewareDependencies): RouteMiddleware 
     // connection when the client goes away — .pipe() does not propagate the
     // client-side close to destroy the source request.
     res.on('close', () => {
-      if (!proxyReq.destroyed) {
+      if (!upgraded && !proxyReq.destroyed) {
         proxyReq.destroy();
       }
     });

--- a/src/socket/proxy-handler.ts
+++ b/src/socket/proxy-handler.ts
@@ -250,9 +250,19 @@ export class ProxyHandler {
     // already freed the parser, making this a safe no-op.
     clientSocket.removeAllListeners('data');
 
+    // Cookies staged by the middleware chain (CloudServer affinity,
+    // X-OPENHAB-AUTH-HEADER) would be lost otherwise — the raw 101 below
+    // bypasses the ServerResponse entirely. Browsers honour Set-Cookie on a
+    // handshake response, so this is what keeps the affinity cookie fresh for
+    // clients whose only traffic is a long-lived WebSocket.
+    const httpResponse = request.response as unknown as import('http').ServerResponse;
+    const setCookie = httpResponse.getHeader('set-cookie');
+    const stagedCookies = setCookie === undefined
+      ? []
+      : (Array.isArray(setCookie) ? setCookie : [String(setCookie)]);
+
     // Detach the ServerResponse from the socket so its lifecycle events
     // (close, finish) don't interfere with the WebSocket connection.
-    const httpResponse = request.response as unknown as import('http').ServerResponse;
     if (typeof httpResponse.detachSocket === 'function') {
       httpResponse.detachSocket(clientSocket);
     }
@@ -271,6 +281,9 @@ export class ProxyHandler {
       } else if (typeof value === 'string') {
         rawResponse += `${safeKey}: ${this.sanitizeHeaderValue(value)}\r\n`;
       }
+    }
+    for (const cookie of stagedCookies) {
+      rawResponse += `Set-Cookie: ${this.sanitizeHeaderValue(cookie)}\r\n`;
     }
     rawResponse += '\r\n';
 

--- a/tests/mocha/unit/routes/middleware.test.ts
+++ b/tests/mocha/unit/routes/middleware.test.ts
@@ -12,6 +12,8 @@
  */
 
 import http from 'http';
+import net from 'net';
+import type { AddressInfo } from 'net';
 import { expect } from 'chai';
 import sinon from 'sinon';
 import type { Request, Response, NextFunction } from 'express';
@@ -583,6 +585,180 @@ describe('Route Middleware', () => {
 
       expect(cookieStub.calledWith('CloudServer', 'server1.internal:3000')).to.be.true;
       expect(nextSpy.calledOnce).to.be.true;
+    });
+  });
+
+  describe('ensureServer WebSocket upgrades', () => {
+    const UPGRADE_RESPONSE =
+      'HTTP/1.1 101 Switching Protocols\r\n'
+      + 'Upgrade: websocket\r\n'
+      + 'Connection: Upgrade\r\n'
+      + 'Sec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=\r\n\r\n';
+
+    let servers: http.Server[] = [];
+
+    const listen = (server: http.Server): Promise<number> => {
+      servers.push(server);
+      return new Promise((resolve) => {
+        server.listen(0, '127.0.0.1', () => {
+          resolve((server.address() as AddressInfo).port);
+        });
+      });
+    };
+
+    // Echoes back whatever the tunnel carries, so the test can prove both
+    // directions are wired up.
+    const echoFrames = (socket: net.Socket) => {
+      socket.on('data', (chunk: Buffer) => {
+        socket.write(Buffer.concat([Buffer.from('echo:'), chunk]));
+      });
+    };
+
+    // Front node: no openHAB connection, so ensureServer proxies onwards.
+    const frontHandler = (
+      middleware: ReturnType<typeof createMiddleware>,
+      targetPort: number
+    ) => (req: http.IncomingMessage, res: http.ServerResponse) => {
+      (req as unknown as Request).connectionInfo = {
+        serverAddress: `127.0.0.1:${targetPort}`,
+      };
+      middleware.ensureServer(
+        req as unknown as Request,
+        res as unknown as Response,
+        (() => {}) as NextFunction
+      );
+    };
+
+    // Sends a raw request, waits for the 101, then round-trips a frame.
+    const openTunnel = (port: number, request: string): Promise<string> =>
+      new Promise((resolve, reject) => {
+        const client = net.connect(port, '127.0.0.1');
+        let received = '';
+        let sentFrame = false;
+
+        client.on('data', (chunk: Buffer) => {
+          received += chunk.toString();
+          if (!sentFrame && received.includes('\r\n\r\n')) {
+            sentFrame = true;
+            client.write('hello');
+          } else if (sentFrame && received.includes('echo:hello')) {
+            client.destroy();
+            resolve(received);
+          }
+        });
+        client.on('error', reject);
+        client.on('close', () => reject(new Error(`socket closed early: ${received}`)));
+        client.write(request);
+      });
+
+    afterEach(() => {
+      for (const server of servers) {
+        server.close();
+      }
+      servers = [];
+    });
+
+    it('tunnels an upgrade that arrives on the HTTP upgrade event', async () => {
+      const targetServer = http.createServer();
+      targetServer.on('upgrade', (_req, socket) => {
+        socket.write(UPGRADE_RESPONSE);
+        echoFrames(socket);
+      });
+      const targetPort = await listen(targetServer);
+
+      const middleware = createMiddleware(deps);
+      const frontServer = http.createServer();
+      // Mirrors app.ts: hand the upgrade to the middleware chain with a
+      // synthetic ServerResponse bound to the client socket.
+      frontServer.on('upgrade', (req, socket, head) => {
+        const res = new http.ServerResponse(req);
+        res.assignSocket(socket);
+        if (head && head.length > 0) {
+          socket.unshift(head);
+        }
+        frontHandler(middleware, targetPort)(req, res);
+      });
+      const frontPort = await listen(frontServer);
+
+      const received = await openTunnel(
+        frontPort,
+        'GET /ws/foo HTTP/1.1\r\n'
+        + 'Host: myopenhab.org\r\n'
+        + 'Upgrade: websocket\r\n'
+        + 'Connection: Upgrade\r\n'
+        + 'Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n'
+        + 'Sec-WebSocket-Version: 13\r\n\r\n'
+      );
+
+      expect(received).to.contain('101 Switching Protocols');
+      expect(received).to.contain('Sec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=');
+      expect(received).to.contain('echo:hello');
+    });
+
+    it('tunnels an upgrade whose hop-by-hop headers were stripped', async () => {
+      // No Upgrade/Connection headers, so both nodes see a plain request and
+      // detect the upgrade from the sec-websocket-* headers instead.
+      const targetServer = http.createServer((_req, res) => {
+        const socket = res.socket as net.Socket;
+        socket.removeAllListeners('data');
+        res.detachSocket(socket);
+        socket.write(UPGRADE_RESPONSE);
+        echoFrames(socket);
+      });
+      const targetPort = await listen(targetServer);
+
+      const middleware = createMiddleware(deps);
+      const frontServer = http.createServer(frontHandler(middleware, targetPort));
+      const frontPort = await listen(frontServer);
+
+      const received = await openTunnel(
+        frontPort,
+        'GET /ws/foo HTTP/1.1\r\n'
+        + 'Host: myopenhab.org\r\n'
+        + 'Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n'
+        + 'Sec-WebSocket-Version: 13\r\n\r\n'
+      );
+
+      expect(received).to.contain('101 Switching Protocols');
+      expect(received).to.contain('echo:hello');
+    });
+
+    it('closes the client socket when the target node goes away', async () => {
+      const targetServer = http.createServer();
+      targetServer.on('upgrade', (_req, socket) => {
+        socket.write(UPGRADE_RESPONSE);
+        socket.destroy();
+      });
+      const targetPort = await listen(targetServer);
+
+      const middleware = createMiddleware(deps);
+      const frontServer = http.createServer();
+      frontServer.on('upgrade', (req, socket) => {
+        const res = new http.ServerResponse(req);
+        res.assignSocket(socket);
+        frontHandler(middleware, targetPort)(req, res);
+      });
+      const frontPort = await listen(frontServer);
+
+      const closed = await new Promise<string>((resolve, reject) => {
+        const client = net.connect(frontPort, '127.0.0.1');
+        let received = '';
+        client.on('data', (chunk: Buffer) => {
+          received += chunk.toString();
+        });
+        client.on('close', () => resolve(received));
+        client.on('error', reject);
+        client.write(
+          'GET /ws/foo HTTP/1.1\r\n'
+          + 'Host: myopenhab.org\r\n'
+          + 'Upgrade: websocket\r\n'
+          + 'Connection: Upgrade\r\n'
+          + 'Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==\r\n'
+          + 'Sec-WebSocket-Version: 13\r\n\r\n'
+        );
+      });
+
+      expect(closed).to.contain('101 Switching Protocols');
     });
   });
 });

--- a/tests/mocha/unit/socket/proxy-handler.test.ts
+++ b/tests/mocha/unit/socket/proxy-handler.test.ts
@@ -1,0 +1,138 @@
+/*
+ * Copyright (c) 2010-2026 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { Types } from 'mongoose';
+import { ProxyHandler } from '../../../../src/socket/proxy-handler';
+import type { RequestTracker } from '../../../../src/socket/request-tracker';
+import type { WebSocketTracker } from '../../../../src/socket/websocket-tracker';
+import type { OpenhabSocket, ResponseHeaderData } from '../../../../src/socket/types';
+import type { IOpenhab } from '../../../../src/types/models';
+import type { Server as SocketIOServer } from 'socket.io';
+
+describe('ProxyHandler WebSocket upgrade', () => {
+  const uuid = 'test-uuid-1';
+  const requestId = 42;
+
+  let handler: ProxyHandler;
+  let clientSocket: { write: sinon.SinonStub; [key: string]: unknown };
+  let response: { socket: unknown; headersSent: boolean; getHeader: sinon.SinonStub };
+  let openhabSocket: OpenhabSocket;
+  let webSocketTracker: { add: sinon.SinonStub };
+
+  const upgradeData: ResponseHeaderData = {
+    id: requestId,
+    responseStatusCode: 101,
+    responseStatusText: 'Switching Protocols',
+    headers: {
+      'Upgrade': 'websocket',
+      'Connection': 'Upgrade',
+      'Sec-WebSocket-Accept': 's3pPLMBiTxaQ9kYGzzhZRbK+xOo=',
+    },
+  } as ResponseHeaderData;
+
+  // The written 101 is a raw byte string, so assertions read it back as text.
+  const writtenResponse = (): string => clientSocket.write.firstCall.args[0] as string;
+
+  beforeEach(() => {
+    clientSocket = {
+      destroyed: false,
+      write: sinon.stub(),
+      removeAllListeners: sinon.stub(),
+      setTimeout: sinon.stub(),
+      setNoDelay: sinon.stub(),
+      resume: sinon.stub(),
+      on: sinon.stub(),
+    };
+
+    response = {
+      socket: clientSocket,
+      headersSent: false,
+      getHeader: sinon.stub().returns(undefined),
+    };
+
+    const openhab = {
+      _id: new Types.ObjectId(),
+      uuid,
+    } as IOpenhab;
+
+    const requestTracker = {
+      has: sinon.stub().returns(true),
+      get: sinon.stub().returns({ openhab, response, headersSent: false }),
+      safeRemove: sinon.stub(),
+      markHeadersSent: sinon.stub(),
+    };
+
+    webSocketTracker = { add: sinon.stub() };
+
+    openhabSocket = {
+      handshake: { uuid },
+      emit: sinon.stub(),
+    } as unknown as OpenhabSocket;
+
+    handler = new ProxyHandler(
+      requestTracker as unknown as RequestTracker,
+      webSocketTracker as unknown as WebSocketTracker,
+      {} as SocketIOServer,
+      { info: sinon.stub(), warn: sinon.stub(), error: sinon.stub(), debug: sinon.stub() }
+    );
+  });
+
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('carries staged cookies into the 101 response', () => {
+    response.getHeader.withArgs('set-cookie').returns([
+      'CloudServer=node2.internal%3A3001; Max-Age=900; Path=/; HttpOnly',
+      'X-OPENHAB-AUTH-HEADER=true; Path=/',
+    ]);
+
+    handler.handleResponseHeader(openhabSocket, upgradeData);
+
+    const raw = writtenResponse();
+    expect(raw).to.contain('HTTP/1.1 101 Switching Protocols');
+    expect(raw).to.contain('Sec-WebSocket-Accept: s3pPLMBiTxaQ9kYGzzhZRbK+xOo=');
+    expect(raw).to.contain('Set-Cookie: CloudServer=node2.internal%3A3001; Max-Age=900; Path=/; HttpOnly');
+    expect(raw).to.contain('Set-Cookie: X-OPENHAB-AUTH-HEADER=true; Path=/');
+    expect(raw.endsWith('\r\n\r\n')).to.be.true;
+    expect(webSocketTracker.add.calledOnce).to.be.true;
+  });
+
+  it('accepts a single staged cookie value', () => {
+    response.getHeader.withArgs('set-cookie').returns('CloudServer=node2.internal%3A3001; Path=/');
+
+    handler.handleResponseHeader(openhabSocket, upgradeData);
+
+    expect(writtenResponse()).to.contain('Set-Cookie: CloudServer=node2.internal%3A3001; Path=/');
+  });
+
+  it('writes no Set-Cookie when nothing was staged', () => {
+    handler.handleResponseHeader(openhabSocket, upgradeData);
+
+    expect(writtenResponse()).to.not.contain('Set-Cookie');
+  });
+
+  it('strips CRLF from staged cookies to prevent response splitting', () => {
+    response.getHeader.withArgs('set-cookie').returns([
+      'CloudServer=evil\r\nX-Injected: yes',
+    ]);
+
+    handler.handleResponseHeader(openhabSocket, upgradeData);
+
+    const raw = writtenResponse();
+    expect(raw).to.contain('Set-Cookie: CloudServer=evilX-Injected: yes');
+    expect(raw.split('\r\n').filter((line) => line.startsWith('X-Injected'))).to.be.empty;
+  });
+});


### PR DESCRIPTION
The internal proxy had no 'upgrade' listener, so a handshake landing on the wrong node was dropped. Tunnel it instead, and carry staged cookies into the 101 so the CloudServer affinity cookie is refreshed on the handshake.